### PR TITLE
Skip tests for LLM classes

### DIFF
--- a/core/llm/llm.test.ts
+++ b/core/llm/llm.test.ts
@@ -148,7 +148,8 @@ function testLLM(
   });
 }
 
-describe("LLM", () => {
+// Granite.Code - we don't need these tests
+describe.skip("LLM", () => {
   testLLM(
     new Anthropic({
       model: "claude-3-5-sonnet-latest",


### PR DESCRIPTION
For Granite.Code, we care only about local models, so rather than
configuring API keys for all the different LLMs in our CI, just
skip the tests.
