### PR TITLE
fix: disable Granite Wizard when running e2e tests

### DIFF
--- a/.github/workflows/pr_checks.yaml
+++ b/.github/workflows/pr_checks.yaml
@@ -631,5 +631,5 @@ jobs:
         uses: re-actors/alls-green@release/v1
         with:
           allowed-failures:
-          allowed-skips:
+          allowed-skips: jetbrains-tests
           jobs: ${{ toJSON(needs) }}

--- a/core/granite/commons/constants.ts
+++ b/core/granite/commons/constants.ts
@@ -1,1 +1,2 @@
 export const isDevMode = process.env.CONTINUE_DEVELOPMENT === "true";
+export const isTestMode = process.env.CONTINUE_GLOBAL_DIR?.includes("e2e/test");

--- a/extensions/vscode/src/activation/activate.ts
+++ b/extensions/vscode/src/activation/activate.ts
@@ -1,3 +1,4 @@
+import { isTestMode } from "core/granite/commons/constants";
 import { getContinueRcPath, getTsConfigPath } from "core/util/paths";
 import { Telemetry } from "core/util/posthog";
 import * as vscode from "vscode";
@@ -34,7 +35,7 @@ export async function activateExtension(context: vscode.ExtensionContext) {
 
   const api = new VsCodeContinueApi(vscodeExtension);
   const showOnboarding = context.globalState.get("showGraniteOnboarding", true);
-  if (showOnboarding) {
+  if (showOnboarding && !isTestMode) {
     await vscode.commands.executeCommand("granite.setup");
     context.globalState.update("showGraniteOnboarding", false);
   }


### PR DESCRIPTION
Checks if CONTINUE_GLOBAL_DIR contains e2e/test to disable wizard popup