### PR TITLE
Disable all commands until Granite has been initialized

### DIFF
--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -158,187 +158,217 @@
         "command": "continue.applyCodeFromChat",
         "category": "Continue",
         "title": "Apply code from chat",
-        "group": "Continue"
+        "group": "Continue",
+        "enablement": "granite.initialized"
       },
       {
         "command": "continue.acceptDiff",
         "category": "Continue",
         "title": "Accept Diff",
-        "group": "Continue"
+        "group": "Continue",
+        "enablement": "granite.initialized"
       },
       {
         "command": "continue.rejectDiff",
         "category": "Continue",
         "title": "Reject Diff",
         "group": "Continue",
-        "icon": "$(stop)"
+        "icon": "$(stop)",
+        "enablement": "granite.initialized"
       },
       {
         "command": "continue.acceptVerticalDiffBlock",
         "category": "Continue",
         "title": "Accept Vertical Diff Block",
-        "group": "Continue"
+        "group": "Continue",
+        "enablement": "granite.initialized"
       },
       {
         "command": "continue.rejectVerticalDiffBlock",
         "category": "Continue",
         "title": "Reject Vertical Diff Block",
-        "group": "Continue"
+        "group": "Continue",
+        "enablement": "granite.initialized"
       },
       {
         "command": "continue.focusEdit",
         "category": "Continue",
         "title": "Generate Code",
-        "group": "Continue"
+        "group": "Continue",
+        "enablement": "granite.initialized"
       },
       {
         "command": "continue.focusContinueInput",
         "category": "Continue",
         "title": "Add Highlighted Code to Context and Clear Chat",
-        "group": "Continue"
+        "group": "Continue",
+        "enablement": "granite.initialized"
       },
       {
         "command": "continue.focusContinueInputWithoutClear",
         "category": "Continue",
         "title": "Add Highlighted Code to Context",
-        "group": "Continue"
+        "group": "Continue",
+        "enablement": "granite.initialized"
       },
       {
         "command": "continue.debugTerminal",
         "category": "Continue",
         "title": "Debug Terminal",
-        "group": "Continue"
+        "group": "Continue",
+        "enablement": "granite.initialized"
       },
       {
         "command": "continue.exitEditMode",
         "category": "Continue",
         "title": "Exit Edit Mode",
-        "group": "Continue"
+        "group": "Continue",
+        "enablement": "granite.initialized"
       },
       {
         "command": "continue.toggleFullScreen",
         "category": "Continue",
         "title": "Open in new window",
         "icon": "$(link-external)",
-        "group": "Continue"
+        "group": "Continue",
+        "enablement": "granite.initialized"
       },
       {
         "command": "continue.openConfigPage",
         "category": "Continue",
         "title": "Open Settings",
         "icon": "$(gear)",
-        "group": "Continue"
+        "group": "Continue",
+        "enablement": "granite.initialized"
       },
       {
         "command": "continue.toggleTabAutocompleteEnabled",
         "category": "Continue",
         "title": "Toggle Autocomplete Enabled",
-        "group": "Continue"
+        "group": "Continue",
+        "enablement": "granite.initialized"
       },
       {
         "command": "continue.selectFilesAsContext",
         "category": "Continue",
         "title": "Select Files as Context",
-        "group": "Continue"
+        "group": "Continue",
+        "enablement": "granite.initialized"
       },
       {
         "command": "continue.newSession",
         "category": "Continue",
         "title": "New Session",
         "icon": "$(add)",
-        "group": "Continue"
+        "group": "Continue",
+        "enablement": "granite.initialized"
       },
       {
         "command": "continue.viewHistory",
         "category": "Continue",
         "title": "View History",
         "icon": "$(history)",
-        "group": "Continue"
+        "group": "Continue",
+        "enablement": "granite.initialized"
       },
       {
         "command": "continue.viewLogs",
         "category": "Continue",
         "title": "View History",
-        "group": "Continue"
+        "group": "Continue",
+        "enablement": "granite.initialized"
       },
       {
         "command": "continue.navigateTo",
         "category": "Continue",
         "title": "Navigate to a path",
-        "group": "Continue"
+        "group": "Continue",
+        "enablement": "granite.initialized"
       },
       {
         "command": "continue.openMorePage",
         "category": "Continue",
         "title": "More",
         "icon": "$(ellipsis)",
-        "group": "Continue"
+        "group": "Continue",
+        "enablement": "granite.initialized"
       },
       {
         "command": "continue.writeCommentsForCode",
         "category": "Continue",
         "title": "Write Comments for this Code",
-        "group": "Continue"
+        "group": "Continue",
+        "enablement": "granite.initialized"
       },
       {
         "command": "continue.writeDocstringForCode",
         "category": "Continue",
         "title": "Write a Docstring for this Code",
-        "group": "Continue"
+        "group": "Continue",
+        "enablement": "granite.initialized"
       },
       {
         "command": "continue.fixCode",
         "category": "Continue",
         "title": "Fix this Code",
-        "group": "Continue"
+        "group": "Continue",
+        "enablement": "granite.initialized"
       },
       {
         "command": "continue.optimizeCode",
         "category": "Continue",
         "title": "Optimize this Code",
-        "group": "Continue"
+        "group": "Continue",
+        "enablement": "granite.initialized"
       },
       {
         "command": "continue.fixGrammar",
         "category": "Continue",
         "title": "Fix Grammar / Spelling",
-        "group": "Continue"
+        "group": "Continue",
+        "enablement": "granite.initialized"
       },
       {
         "command": "continue.codebaseForceReIndex",
         "category": "Continue",
         "title": "Codebase Force Re-Index",
-        "group": "Continue"
+        "group": "Continue",
+        "enablement": "granite.initialized"
       },
       {
         "command": "continue.rebuildCodebaseIndex",
         "category": "Continue",
         "title": "Rebuild codebase index",
-        "group": "Continue"
+        "group": "Continue",
+        "enablement": "granite.initialized"
       },
       {
         "command": "continue.docsIndex",
         "category": "Continue",
         "title": "Docs Index",
-        "group": "Continue"
+        "group": "Continue",
+        "enablement": "granite.initialized"
       },
       {
         "command": "continue.docsReIndex",
         "category": "Continue",
         "title": "Docs Force Re-Index",
-        "group": "Continue"
+        "group": "Continue",
+        "enablement": "granite.initialized"
       },
       {
         "command": "continue.focusContinueSessionId",
         "category": "Continue",
         "title": "Focus Continue Chat",
-        "group": "Continue"
+        "group": "Continue",
+        "enablement": "granite.initialized"
       },
       {
         "command": "granite.writeContinueConfig",
         "title": "Write Continue Config",
         "category": "Granite.Code",
-        "group": "Granite.Code"
+        "group": "Granite.Code",
+        "enablement": "granite.initialized"
       },
       {
         "command": "granite.setup",

--- a/extensions/vscode/src/activation/activate.ts
+++ b/extensions/vscode/src/activation/activate.ts
@@ -1,5 +1,7 @@
-import { isTestMode } from "core/granite/commons/constants";
-import { SHOW_GRANITE_ONBOARDING_CARD_KEY } from "core/granite/commons/constants";
+import {
+  isTestMode,
+  SHOW_GRANITE_ONBOARDING_CARD_KEY,
+} from "core/granite/commons/constants";
 import { getContinueRcPath, getTsConfigPath } from "core/util/paths";
 import { Telemetry } from "core/util/posthog";
 import * as vscode from "vscode";
@@ -38,6 +40,11 @@ export async function activateExtension(context: vscode.ExtensionContext) {
   const showOnboarding = context.globalState.get(
     SHOW_GRANITE_ONBOARDING_CARD_KEY,
     true,
+  );
+  vscode.commands.executeCommand(
+    "setContext",
+    "granite.initialized",
+    !showOnboarding || isTestMode,
   );
   if (showOnboarding && !isTestMode) {
     await vscode.commands.executeCommand("granite.setup");

--- a/extensions/vscode/src/granite/panels/setupGranitePage.ts
+++ b/extensions/vscode/src/granite/panels/setupGranitePage.ts
@@ -22,14 +22,14 @@ import {
   workspace,
 } from "vscode";
 
+import { LocalModelSize } from "core";
+import { SHOW_GRANITE_ONBOARDING_CARD_KEY } from "core/granite/commons/constants";
+import { VsCodeWebviewProtocol } from "../../webviewProtocol";
 import { OllamaServer } from "../ollama/ollamaServer";
+import { CancellationController } from "../utils/cancellationController";
 import { getNonce } from "../utils/getNonce";
 import { getUri } from "../utils/getUri";
 import { getSystemInfo } from "../utils/sysUtils";
-import { LocalModelSize } from "core";
-import { CancellationController } from "../utils/cancellationController";
-import { VsCodeWebviewProtocol } from "../../webviewProtocol";
-import { SHOW_GRANITE_ONBOARDING_CARD_KEY } from "core/granite/commons/constants";
 
 /**
  * This class manages the state and behavior of HelloWorld webview panels.
@@ -420,6 +420,7 @@ export class SetupGranitePage {
 
   private hideGraniteOnboardingCard() {
     this.context.globalState.update(SHOW_GRANITE_ONBOARDING_CARD_KEY, false);
+    commands.executeCommand("setContext", "granite.initialized", true);
     this.chatWebViewProtocol.send("setShowGraniteOnboardingCard", false);
   }
 


### PR DESCRIPTION
## Description

Disable all commands until Granite.Code has been initialized.
Fixes https://github.com/Granite-Code/granite-code/issues/51

We can also completely remove the Continue menus on right click, instead of seeing them disabled, but I think they serve as a good reminder the menus exist but are disabled on purpose. @allanday @owtaylor wdyt?

## Screenshots
<img width="1840" alt="Screenshot 2025-03-07 at 16 40 13" src="https://github.com/user-attachments/assets/8a9464a4-c41f-489e-a9ef-426a3f20c4e2" />

<img width="1840" alt="Screenshot 2025-03-07 at 16 40 29" src="https://github.com/user-attachments/assets/57a72bc1-1caa-46d3-8d29-1c77ca0d64d8" />


## Testing instructions
- close vscode entirely (make sure there are no open processes)
- delete the continue global context state. You'll need to locate the User/globalStorage/state.vscdb on your platform. On mac, you can do: 
> sqlite3 ~/Library/Application\ Support/Code/User/globalStorage/state.vscdb 'delete from ItemTable where key="Continue.continue";'
- run the extension in dev mode and check no Continue command is enabled until setup is complete

