### PR TITLE
feat: use Granite.Code specific tutorial file

### DIFF
--- a/extensions/vscode/granitecode_tutorial.py
+++ b/extensions/vscode/granitecode_tutorial.py
@@ -1,0 +1,40 @@
+"""
+                                        GRANITE CODE TUTORIAL
+                                 Chat, Edit, and Autocomplete tutorial
+"""
+
+
+# —————————————————————————————————————————————————     Chat      ————————————————————————————————————————————————— #
+
+## Highlight the code below
+## Press [Cmd + L] to add to Chat
+## Try asking Granite.Code "what sorting algorithm is this?"
+def sorting_algorithm(x):
+    for i in range(len(x)):
+        for j in range(len(x) - 1):
+            if x[j] > x[j + 1]:
+                x[j], x[j + 1] = x[j + 1], x[j]
+    return x
+
+
+# —————————————————————————————————————————————————     Edit      ————————————————————————————————————————————————— #
+
+## Highlight the code below
+## Press [Cmd + I] to Edit
+## Try asking Granite.Code to "make this more readable"
+def sorting_algorithm(x):
+    for i in range(len(x)):
+        for j in range(len(x) - 1):
+            if x[j] > x[j + 1]:
+                x[j], x[j + 1] = x[j + 1], x[j]
+    return x
+
+# —————————————————————————————————————————————     Autocomplete     —————————————————————————————————————————————— #
+
+## Place cursor after `sorting_algorithm...` below and press [Enter]
+## Press [Tab] to accept the Autocomplete suggestion
+
+# Basic assertion for sorting_algorithm...
+
+
+# ——————————————————      Learn more at https://granite.code.dev/    ————————————————————————————————————————————— #

--- a/extensions/vscode/scripts/prepackage-cross-platform.js
+++ b/extensions/vscode/scripts/prepackage-cross-platform.js
@@ -171,7 +171,7 @@ async function package(target, os, arch, exe) {
 
     // Tutorial
     "media/move-chat-panel-right.md",
-    "continue_tutorial.py",
+    "granitecode_tutorial.py",
     "config_schema.json",
 
     // Embeddings model

--- a/extensions/vscode/scripts/prepackage.js
+++ b/extensions/vscode/scripts/prepackage.js
@@ -486,7 +486,7 @@ const isMacTarget = target?.startsWith("darwin");
 
     // Tutorial
     "media/move-chat-panel-right.md",
-    "continue_tutorial.py",
+    "granitecode_tutorial.py",
     "config_schema.json",
 
     // Embeddings model

--- a/extensions/vscode/src/granite/panels/setupGranitePage.ts
+++ b/extensions/vscode/src/granite/panels/setupGranitePage.ts
@@ -396,7 +396,7 @@ export class SetupGranitePage {
       if (result) {
         await this.saveSettings(modelSize);
         this.hideGraniteOnboardingCard();
-
+        commands.executeCommand("continue.continueGUIView.focus");
         if (!panel.visible) {
           const selection = await window.showInformationMessage(
             "Granite.Code is ready to be used.",

--- a/extensions/vscode/src/util/tutorial.ts
+++ b/extensions/vscode/src/util/tutorial.ts
@@ -2,7 +2,7 @@ import { IDE } from "core";
 import { getExtensionUri } from "./vscode";
 import * as vscode from "vscode";
 
-const TUTORIAL_FILE_NAME = "continue_tutorial.py";
+const TUTORIAL_FILE_NAME = "granitecode_tutorial.py";
 export function getTutorialUri(): vscode.Uri {
   return vscode.Uri.joinPath(getExtensionUri(), TUTORIAL_FILE_NAME);
 }


### PR DESCRIPTION
## Description

- Open a granite.code specific tutorial file
- Open the granite.code view once the wizard setup is complete

I initially went with a notebook instead of a raw python file, but it's impossible to copy text from notebook markdown, found that frustrating so didn't go with it.

Fixes https://github.com/Granite-Code/granite-code/issues/63
