### PR TITLE
Disable irrelevant continue features

### DIFF
--- a/core/util/constants.ts
+++ b/core/util/constants.ts
@@ -1,5 +1,5 @@
 export const NEW_SESSION_TITLE = "New Session";
 
 export const GITHUB_LINK =
-  "https://github.com/continuedev/continue/issues/new/choose";
+  "https://github.com/Granite-Code/granite-code/issues/new";
 export const DISCORD_LINK = "https://discord.com/invite/EfJEfdFnDQ";

--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -555,6 +555,11 @@
           "when": "view == continue.continueGUIView"
         },
         {
+          "command": "continue.openConfigPage",
+          "group": "navigation@4",
+          "when": "view == continue.continueGUIView"
+        },
+        {
           "command": "continue.openMorePage",
           "group": "navigation@6",
           "when": "view == continue.continueGUIView"

--- a/gui/src/components/mainInput/InputToolbar.tsx
+++ b/gui/src/components/mainInput/InputToolbar.tsx
@@ -27,7 +27,6 @@ import {
 import { ToolTip } from "../gui/Tooltip";
 import ModelSelect from "../modelSelection/ModelSelect";
 import HoverItem from "./InputToolbar/HoverItem";
-import ToggleToolsButton from "./InputToolbar/ToggleToolsButton";
 
 const StyledDiv = styled.div<{ isHidden?: boolean }>`
   padding-top: 4px;
@@ -153,7 +152,7 @@ function InputToolbar(props: InputToolbarProps) {
               </HoverItem>
             )}
 
-            <ToggleToolsButton disabled={!toolsSupported} />
+            {/* <ToggleToolsButton disabled={!toolsSupported} /> FIXME ensure Granite models properly support tools */}
           </div>
         </div>
 

--- a/gui/src/pages/More/More.tsx
+++ b/gui/src/pages/More/More.tsx
@@ -98,15 +98,6 @@ function MorePage() {
             />
 
             <MoreHelpRow
-              title="Join the community!"
-              description="Join us on Discord to stay up-to-date on the latest developments"
-              Icon={ArrowTopRightOnSquareIcon}
-              onClick={() =>
-                ideMessenger.post("openUrl", "https://discord.gg/vapESyrFmJ")
-              }
-            />
-
-            <MoreHelpRow
               title="Token usage"
               description="Daily token usage across models"
               Icon={TableCellsIcon}

--- a/gui/src/pages/config/index.tsx
+++ b/gui/src/pages/config/index.tsx
@@ -48,12 +48,7 @@ function ConfigPage() {
     dispatch(selectProfileThunk(id));
   };
 
-  const [hubEnabled, setHubEnabled] = useState(false);
-  useEffect(() => {
-    ideMessenger.ide.getIdeSettings().then(({ continueTestEnvironment }) => {
-      setHubEnabled(continueTestEnvironment === "production");
-    });
-  }, [ideMessenger]);
+  const hubEnabled = false;
 
   function handleOpenConfig() {
     if (!selectedProfile) {
@@ -223,7 +218,7 @@ function ConfigPage() {
         <div className="flex flex-col">
           <div className="flex max-w-[400px] flex-col gap-4 py-6">
             <h2 className="mb-1 mt-0">Configuration</h2>
-            {profiles ? (
+            {hubEnabled && profiles ? (
               <>
                 <div className="flex flex-col gap-1.5">
                   <span className="text-lightgray">{`${hubEnabled ? "Assistant" : "Profile"}`}</span>
@@ -314,7 +309,7 @@ function ConfigPage() {
                 )} */}
               </>
             ) : (
-              <div>Loading...</div>
+              hubEnabled && <div>Loading...</div>
             )}
             <div>
               <h2 className="m-0 mb-3 p-0 text-center text-sm">Model Roles</h2>

--- a/gui/src/pages/error.tsx
+++ b/gui/src/pages/error.tsx
@@ -2,12 +2,11 @@ import { useDispatch } from "react-redux";
 import { useNavigate, useRouteError } from "react-router-dom";
 import { newSession } from "../redux/slices/sessionSlice";
 import { GithubIcon } from "../components/svg/GithubIcon";
-import { DiscordIcon } from "../components/svg/DiscordIcon";
 import { useContext, useEffect, useState } from "react";
 import { IdeMessengerContext } from "../context/IdeMessenger";
 import { Button, SecondaryButton } from "../components";
 import { ArrowPathIcon, FlagIcon } from "@heroicons/react/24/outline";
-import { DISCORD_LINK, GITHUB_LINK } from "core/util/constants";
+import { GITHUB_LINK } from "core/util/constants";
 
 const ErrorPage: React.FC = () => {
   const error: any = useRouteError();
@@ -58,7 +57,7 @@ const ErrorPage: React.FC = () => {
       </Button>
 
       <p className="mb-0 mt-6 text-lg">
-        Report the issue on GitHub or Discord:
+        Report the issue on GitHub :
       </p>
 
       <div className="flex space-x-4">
@@ -67,12 +66,6 @@ const ErrorPage: React.FC = () => {
           className="flex w-full items-center justify-center space-x-2 rounded-lg px-4 py-2 text-base text-white"
         >
           <GithubIcon size={20} /> <span className="ml-2">GitHub</span>
-        </SecondaryButton>
-        <SecondaryButton
-          onClick={() => openUrl(DISCORD_LINK)}
-          className="flex w-full items-center justify-center rounded-lg text-base"
-        >
-          <DiscordIcon size={20} /> <span className="ml-2">Discord</span>
         </SecondaryButton>
       </div>
     </div>

--- a/gui/src/pages/gui/Chat.tsx
+++ b/gui/src/pages/gui/Chat.tsx
@@ -43,7 +43,6 @@ import { IdeMessengerContext } from "../../context/IdeMessenger";
 import { useTutorialCard } from "../../hooks/useTutorialCard";
 import { useWebviewListener } from "../../hooks/useWebviewListener";
 import { useAppDispatch, useAppSelector } from "../../redux/hooks";
-import { selectUseHub } from "../../redux/selectors";
 import { selectCurrentToolCall } from "../../redux/selectors/selectCurrentToolCall";
 import { selectDefaultModel } from "../../redux/slices/configSlice";
 import { submitEdit } from "../../redux/slices/editModeState";
@@ -226,7 +225,7 @@ export function Chat() {
     selectIsSingleRangeEditOrInsertion,
   );
   const lastSessionId = useAppSelector((state) => state.session.lastSessionId);
-  const useHub = useAppSelector(selectUseHub);
+  const useHub = false;//useAppSelector(selectUseHub);
 
   useEffect(() => {
     // Cmd + Backspace to delete current step

--- a/gui/src/pages/gui/StreamError.tsx
+++ b/gui/src/pages/gui/StreamError.tsx
@@ -1,8 +1,7 @@
 import { Cog8ToothIcon } from "@heroicons/react/24/outline";
-import { DISCORD_LINK, GITHUB_LINK } from "core/util/constants";
+import { GITHUB_LINK } from "core/util/constants";
 import { useContext } from "react";
 import { Button, SecondaryButton } from "../../components";
-import { DiscordIcon } from "../../components/svg/DiscordIcon";
 import { GithubIcon } from "../../components/svg/GithubIcon";
 import { useAuth } from "../../context/Auth";
 import { IdeMessengerContext } from "../../context/IdeMessenger";
@@ -236,15 +235,6 @@ const StreamErrorDialog = ({ error }: StreamErrorProps) => {
           >
             <GithubIcon className="h-5 w-5" />
             <span className="xs:flex hidden">Github</span>
-          </SecondaryButton>
-          <SecondaryButton
-            className="flex flex-row items-center gap-2 hover:opacity-70"
-            onClick={() => {
-              ideMessenger.post("openUrl", DISCORD_LINK);
-            }}
-          >
-            <DiscordIcon className="h-5 w-5" />
-            <span className="xs:flex hidden">Discord</span>
           </SecondaryButton>
         </div>
         <div className="flex flex-row justify-end">

--- a/gui/src/pages/migration.tsx
+++ b/gui/src/pages/migration.tsx
@@ -28,10 +28,6 @@ function MigrationPage() {
         >
           migration walkthrough
         </a>
-        , and if you have any questions please reach out to us on{" "}
-        <a href="https://discord.gg/Y83xkG3uUW" target="_blank">
-          Discord
-        </a>
         .
       </p>
 


### PR DESCRIPTION
## Description

- removed Profile and Tools selectors in the Chat view
- removed links to Continue Discord shown on error
- restored Settings (gear) icon in Chat view
- removed assistant section and profile selector in the Settings page
- switched GITHUB_LINK to Granite.Code's repo

Fixes https://github.com/Granite-Code/granite-code/issues/64

![Mar-14-2025 14-51-32](https://github.com/user-attachments/assets/af4c7689-efbc-42aa-8a08-68d1f3475563)

