### PR TITLE
feat: add regular model update checks

### DIFF
--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -150,6 +150,12 @@
           ],
           "default": "large",
           "description": "Whether to use a small or large local model. Small models are faster but less accurate."
+        },
+        "continue.checkModelUpdates": {
+          "type": "boolean",
+          "default": true,
+          "title": "Check For Model Updates",
+          "description": "Controls whether a daily check is performed for Granite.Code model updates"
         }
       }
     },
@@ -674,7 +680,7 @@
     "@vscode/vsce": "^2.22.0",
     "cargo-cp-artifact": "^0.1",
     "chai": "^4.5.0",
-    "esbuild": "0.17.19",
+    "esbuild": "^0.17.19",
     "esbuild-visualizer": "^0.6.0",
     "eslint": "^8.28.0",
     "glob": "^8.0.3",
@@ -703,7 +709,6 @@
     "dbinfoz": "^0.14.0",
     "diff": "^7.0.0",
     "downshift": "^7.6.0",
-    "esbuild": "0.17.19",
     "express": "^4.18.2",
     "fkill": "^8.1.0",
     "follow-redirects": "^1.15.4",

--- a/extensions/vscode/src/ContinueGUIWebviewViewProvider.ts
+++ b/extensions/vscode/src/ContinueGUIWebviewViewProvider.ts
@@ -1,10 +1,7 @@
 import { ConfigHandler } from "core/config/ConfigHandler";
-import {
-  isTestMode,
-  SHOW_GRANITE_ONBOARDING_CARD_KEY,
-} from "core/granite/commons/constants";
 import * as vscode from "vscode";
 
+import { isGraniteOnboardingComplete } from "./granite/utils/extensionUtils";
 import { getTheme } from "./util/getTheme";
 import { getExtensionVersion } from "./util/util";
 import { getExtensionUri, getNonce, getUniqueId } from "./util/vscode";
@@ -172,7 +169,7 @@ export class ContinueGUIWebviewViewProvider
         <script>window.ide = "vscode"</script>
         <script>window.fullColorTheme = ${JSON.stringify(currentTheme)}</script>
         <script>window.colorThemeName = "dark-plus"</script>
-        <script>window.showGraniteCodeOnboarding = ${this.extensionContext.globalState.get(SHOW_GRANITE_ONBOARDING_CARD_KEY, true) && !isTestMode}</script>
+        <script>window.showGraniteCodeOnboarding = ${!isGraniteOnboardingComplete(this.extensionContext)}</script>
         <script>window.workspacePaths = ${JSON.stringify(
           vscode.workspace.workspaceFolders?.map((folder) =>
             folder.uri.toString(),

--- a/extensions/vscode/src/activation/activate.ts
+++ b/extensions/vscode/src/activation/activate.ts
@@ -7,6 +7,7 @@ import { Telemetry } from "core/util/posthog";
 import * as vscode from "vscode";
 
 import { VsCodeExtension } from "../extension/VsCodeExtension";
+import { registerModelUpdateProvider } from "../granite/ollama/modelUpdater";
 import registerQuickFixProvider from "../lang-server/codeActions";
 import { getExtensionVersion } from "../util/util";
 
@@ -49,6 +50,8 @@ export async function activateExtension(context: vscode.ExtensionContext) {
   if (showOnboarding && !isTestMode) {
     await vscode.commands.executeCommand("granite.setup");
   }
+
+  registerModelUpdateProvider(context);
 
   const continuePublicApi = {
     registerCustomContextProvider: api.registerCustomContextProvider.bind(api),

--- a/extensions/vscode/src/activation/activate.ts
+++ b/extensions/vscode/src/activation/activate.ts
@@ -1,13 +1,10 @@
-import {
-  isTestMode,
-  SHOW_GRANITE_ONBOARDING_CARD_KEY,
-} from "core/granite/commons/constants";
 import { getContinueRcPath, getTsConfigPath } from "core/util/paths";
 import { Telemetry } from "core/util/posthog";
 import * as vscode from "vscode";
 
 import { VsCodeExtension } from "../extension/VsCodeExtension";
-import { registerModelUpdateProvider } from "../granite/ollama/modelUpdater";
+import { registerModelUpdater } from "../granite/ollama/modelUpdater";
+import { isGraniteOnboardingComplete } from "../granite/utils/extensionUtils";
 import registerQuickFixProvider from "../lang-server/codeActions";
 import { getExtensionVersion } from "../util/util";
 
@@ -38,20 +35,17 @@ export async function activateExtension(context: vscode.ExtensionContext) {
   }
 
   const api = new VsCodeContinueApi(vscodeExtension);
-  const showOnboarding = context.globalState.get(
-    SHOW_GRANITE_ONBOARDING_CARD_KEY,
-    true,
-  );
+  const showOnboarding = !isGraniteOnboardingComplete(context);
   vscode.commands.executeCommand(
     "setContext",
     "granite.initialized",
-    !showOnboarding || isTestMode,
+    !showOnboarding,
   );
-  if (showOnboarding && !isTestMode) {
+  if (showOnboarding) {
     await vscode.commands.executeCommand("granite.setup");
   }
 
-  registerModelUpdateProvider(context);
+  registerModelUpdater(context);
 
   const continuePublicApi = {
     registerCustomContextProvider: api.registerCustomContextProvider.bind(api),

--- a/extensions/vscode/src/granite/modelServer.ts
+++ b/extensions/vscode/src/granite/modelServer.ts
@@ -1,6 +1,5 @@
 import { ProgressData } from "core/granite/commons/progressData";
 import { ModelStatus, ServerStatus } from "core/granite/commons/statuses";
-import { LocalModelSize } from "core";
 
 export interface IModelServer {
   getName(): string;
@@ -11,6 +10,6 @@ export interface IModelServer {
   startServer(): Promise<boolean>;
   installServer(mode: string, signal: AbortSignal, reportProgress: (progress: ProgressData) => void): Promise<boolean>;
   getModelStatus(modelName?: string): Promise<ModelStatus>;
-  pullModels(type: LocalModelSize, signal: AbortSignal, reportProgress: (progress: ProgressData) => void): Promise<boolean>;
+  pullModels(models: string[], signal: AbortSignal, reportProgress: (progress: ProgressData) => void): Promise<boolean>;
   listModels(): Promise<string[]>;
 }

--- a/extensions/vscode/src/granite/ollama/modelUpdater.ts
+++ b/extensions/vscode/src/granite/ollama/modelUpdater.ts
@@ -1,0 +1,187 @@
+import { LocalModelSize } from "core";
+import {
+  DEFAULT_MODEL_GRANITE_LARGE,
+  DEFAULT_MODEL_GRANITE_SMALL,
+} from "core/config/default";
+import { EXTENSION_NAME } from "core/control-plane/env";
+import { SHOW_GRANITE_ONBOARDING_CARD_KEY } from "core/granite/commons/constants";
+import { ProgressData } from "core/granite/commons/progressData";
+import { ModelStatus } from "core/granite/commons/statuses";
+import { formatSize } from "core/granite/commons/textUtils";
+import { ExtensionContext, ProgressLocation, window, workspace } from "vscode";
+
+import { OllamaServer } from "./ollamaServer";
+
+const UPDATE_INTERVAL = 24 * 60 * 60 * 1000; // 24 hours
+const USER_OPTIONS = {
+  UPDATE: "Update",
+  CANCEL: "Cancel",
+} as const;
+
+type UpdaterState = {
+  updateInterval?: NodeJS.Timeout;
+  checkNow: () => boolean;
+  ollamaServer: OllamaServer;
+};
+
+async function enableModelUpdateCheck(state: UpdaterState): Promise<void> {
+  console.log("Enabling model update check");
+  state.updateInterval = setInterval(
+    () => checkModelUpdates(state),
+    UPDATE_INTERVAL,
+  );
+  if (state.checkNow()) {
+    await checkModelUpdates(state);
+  }
+}
+
+function disableModelUpdateCheck(state: UpdaterState): void {
+  console.log("Disabling model update check");
+  if (state.updateInterval) {
+    clearInterval(state.updateInterval);
+    state.updateInterval = undefined;
+  }
+}
+
+async function checkModelUpdates(state: UpdaterState): Promise<void> {
+  try {
+    console.log("Checking for model updates...");
+    const type = workspace
+      .getConfiguration(EXTENSION_NAME)
+      .get<LocalModelSize>("modelSize");
+    const graniteModel =
+      type === "large"
+        ? DEFAULT_MODEL_GRANITE_LARGE
+        : DEFAULT_MODEL_GRANITE_SMALL;
+    const modelsToCheck = [graniteModel.model, "nomic-embed-text:latest"];
+
+    const modelsToUpdate = await Promise.all(
+      modelsToCheck.map(async (model) => {
+        try {
+          const modelStatus = await state.ollamaServer.getModelStatus(
+            model,
+            true,
+          );
+          return modelStatus === ModelStatus.stale ||
+            modelStatus === ModelStatus.missing //missing if the extension was updated and configured a new model id
+            ? model
+            : null;
+        } catch (error) {
+          console.error(`Failed to check status for model ${model}:`, error);
+          return null;
+        }
+      }),
+    ).then((results) =>
+      results.filter((model): model is string => model !== null),
+    );
+
+    if (modelsToUpdate.length === 0) {
+      console.log("No models to update");
+      return;
+    }
+
+    const downloadSize = (
+      await Promise.all(
+        modelsToUpdate.map(async (model) => {
+          const modelInfo = await state.ollamaServer.getModelInfo(model);
+          return modelInfo?.size || 0;
+        }),
+      )
+    ).reduce((total, modelSize) => total + modelSize, 0);
+
+    console.log("Models requiring update:", modelsToUpdate);
+    const userChoice = await window.showInformationMessage(
+      `Granite.Code model updates available. Update requires ${formatSize(downloadSize)} download.`,
+      USER_OPTIONS.UPDATE,
+      USER_OPTIONS.CANCEL,
+    );
+
+    if (userChoice === USER_OPTIONS.UPDATE) {
+      await updateModels(state.ollamaServer, modelsToUpdate);
+    }
+  } catch (error) {
+    console.error("Error during model update check:", error);
+  }
+}
+
+async function updateModels(
+  ollamaServer: OllamaServer,
+  models: string[],
+): Promise<void> {
+  return window.withProgress(
+    {
+      location: ProgressLocation.Notification,
+      title: "Updating Granite.Code models",
+      cancellable: true,
+    },
+    async (progress, token) => {
+      const abortController = new AbortController();
+      token.onCancellationRequested(() => {
+        console.log("Model update cancelled by user");
+        abortController.abort();
+      });
+      const progressWrapper = (data: ProgressData): void => {
+        const completed = data.completed ?? 0;
+        const total = data.total ?? 0;
+        let message = data.status;
+
+        if (total > 0) {
+          const progressPercent = Math.round((completed / total) * 100);
+          message = `${message} ${progressPercent}%`;
+        }
+        const increment = data.increment ? (data.increment / total) * 100 : 0;
+        progress.report({ increment, message });
+      };
+
+      try {
+        await ollamaServer.pullModels(
+          models,
+          abortController.signal,
+          progressWrapper,
+        );
+      } catch (error) {
+        if (!abortController.signal.aborted) {
+          console.error("Failed to update models:", error);
+          window.showErrorMessage(
+            "Failed to update models. Please try again later.",
+          );
+        }
+      }
+    },
+  );
+}
+
+async function configureModelUpdateCheck(state: UpdaterState): Promise<void> {
+  const checkUpdates = workspace
+    .getConfiguration(EXTENSION_NAME)
+    .get<boolean>("checkModelUpdates", true);
+
+  if (checkUpdates) {
+    if (!state.updateInterval) {
+      await enableModelUpdateCheck(state);
+    }
+  } else {
+    disableModelUpdateCheck(state);
+  }
+}
+
+export async function registerModelUpdateProvider(
+  context: ExtensionContext,
+): Promise<void> {
+  const state: UpdaterState = {
+    ollamaServer: new OllamaServer(context),
+    checkNow: () => {
+      //Don't check now if onboarding is not completed
+      return !context.globalState.get(SHOW_GRANITE_ONBOARDING_CARD_KEY, true);
+    },
+  };
+
+  context.subscriptions.push(
+    workspace.onDidChangeConfiguration(async (e) => {
+      if (e.affectsConfiguration(`${EXTENSION_NAME}.checkModelUpdates`)) {
+        await configureModelUpdateCheck(state);
+      }
+    }),
+  );
+  await configureModelUpdateCheck(state);
+}

--- a/extensions/vscode/src/granite/ollama/modelUpdater.ts
+++ b/extensions/vscode/src/granite/ollama/modelUpdater.ts
@@ -4,11 +4,18 @@ import {
   DEFAULT_MODEL_GRANITE_SMALL,
 } from "core/config/default";
 import { EXTENSION_NAME } from "core/control-plane/env";
-import { SHOW_GRANITE_ONBOARDING_CARD_KEY } from "core/granite/commons/constants";
 import { ProgressData } from "core/granite/commons/progressData";
 import { ModelStatus } from "core/granite/commons/statuses";
 import { formatSize } from "core/granite/commons/textUtils";
-import { ExtensionContext, ProgressLocation, window, workspace } from "vscode";
+import {
+  Disposable,
+  ExtensionContext,
+  ProgressLocation,
+  window,
+  workspace,
+} from "vscode";
+
+import { isGraniteOnboardingComplete } from "../utils/extensionUtils";
 
 import { OllamaServer } from "./ollamaServer";
 
@@ -18,170 +25,177 @@ const USER_OPTIONS = {
   CANCEL: "Cancel",
 } as const;
 
-type UpdaterState = {
-  updateInterval?: NodeJS.Timeout;
-  checkNow: () => boolean;
-  ollamaServer: OllamaServer;
-};
+export class ModelUpdater implements Disposable {
+  private updateInterval?: NodeJS.Timeout;
+  private readonly ollamaServer: OllamaServer;
+  private readonly context: ExtensionContext;
 
-async function enableModelUpdateCheck(state: UpdaterState): Promise<void> {
-  console.log("Enabling model update check");
-  state.updateInterval = setInterval(
-    () => checkModelUpdates(state),
-    UPDATE_INTERVAL,
-  );
-  if (state.checkNow()) {
-    await checkModelUpdates(state);
+  constructor(context: ExtensionContext) {
+    this.context = context;
+    this.ollamaServer = new OllamaServer(context);
   }
-}
 
-function disableModelUpdateCheck(state: UpdaterState): void {
-  console.log("Disabling model update check");
-  if (state.updateInterval) {
-    clearInterval(state.updateInterval);
-    state.updateInterval = undefined;
+  private shouldCheckNow(): boolean {
+    //Don't check now if onboarding is not completed
+    return isGraniteOnboardingComplete(this.context);
   }
-}
 
-async function checkModelUpdates(state: UpdaterState): Promise<void> {
-  try {
-    console.log("Checking for model updates...");
-    const type = workspace
-      .getConfiguration(EXTENSION_NAME)
-      .get<LocalModelSize>("modelSize");
-    const graniteModel =
-      type === "large"
-        ? DEFAULT_MODEL_GRANITE_LARGE
-        : DEFAULT_MODEL_GRANITE_SMALL;
-    const modelsToCheck = [graniteModel.model, "nomic-embed-text:latest"];
-
-    const modelsToUpdate = await Promise.all(
-      modelsToCheck.map(async (model) => {
-        try {
-          const modelStatus = await state.ollamaServer.getModelStatus(
-            model,
-            true,
-          );
-          return modelStatus === ModelStatus.stale ||
-            modelStatus === ModelStatus.missing //missing if the extension was updated and configured a new model id
-            ? model
-            : null;
-        } catch (error) {
-          console.error(`Failed to check status for model ${model}:`, error);
-          return null;
-        }
-      }),
-    ).then((results) =>
-      results.filter((model): model is string => model !== null),
-    );
-
-    if (modelsToUpdate.length === 0) {
-      console.log("No models to update");
+  private async enableModelUpdateCheck(): Promise<void> {
+    if (this.updateInterval) {
       return;
     }
-
-    const downloadSize = (
-      await Promise.all(
-        modelsToUpdate.map(async (model) => {
-          const modelInfo = await state.ollamaServer.getModelInfo(model);
-          return modelInfo?.size || 0;
-        }),
-      )
-    ).reduce((total, modelSize) => total + modelSize, 0);
-
-    console.log("Models requiring update:", modelsToUpdate);
-    const userChoice = await window.showInformationMessage(
-      `Granite.Code model updates available. Update requires ${formatSize(downloadSize)} download.`,
-      USER_OPTIONS.UPDATE,
-      USER_OPTIONS.CANCEL,
+    console.log("Enabling model update check");
+    this.updateInterval = setInterval(
+      () => this.checkModelUpdates(),
+      UPDATE_INTERVAL,
     );
-
-    if (userChoice === USER_OPTIONS.UPDATE) {
-      await updateModels(state.ollamaServer, modelsToUpdate);
+    if (this.shouldCheckNow()) {
+      await this.checkModelUpdates();
     }
-  } catch (error) {
-    console.error("Error during model update check:", error);
   }
-}
 
-async function updateModels(
-  ollamaServer: OllamaServer,
-  models: string[],
-): Promise<void> {
-  return window.withProgress(
-    {
-      location: ProgressLocation.Notification,
-      title: "Updating Granite.Code models",
-      cancellable: true,
-    },
-    async (progress, token) => {
-      const abortController = new AbortController();
-      token.onCancellationRequested(() => {
-        console.log("Model update cancelled by user");
-        abortController.abort();
-      });
-      const progressWrapper = (data: ProgressData): void => {
-        const completed = data.completed ?? 0;
-        const total = data.total ?? 0;
-        let message = data.status;
+  private disableModelUpdateCheck(): void {
+    console.log("Disabling model update check");
+    if (this.updateInterval) {
+      clearInterval(this.updateInterval);
+      this.updateInterval = undefined;
+    }
+  }
 
-        if (total > 0) {
-          const progressPercent = Math.round((completed / total) * 100);
-          message = `${message} ${progressPercent}%`;
-        }
-        const increment = data.increment ? (data.increment / total) * 100 : 0;
-        progress.report({ increment, message });
-      };
+  private async checkModelUpdates(): Promise<void> {
+    try {
+      console.log("Checking for model updates...");
+      const type = workspace
+        .getConfiguration(EXTENSION_NAME)
+        .get<LocalModelSize>("modelSize");
+      const graniteModel =
+        type === "large"
+          ? DEFAULT_MODEL_GRANITE_LARGE
+          : DEFAULT_MODEL_GRANITE_SMALL;
+      const modelsToCheck = [graniteModel.model, "nomic-embed-text:latest"];
 
-      try {
-        await ollamaServer.pullModels(
-          models,
-          abortController.signal,
-          progressWrapper,
-        );
-      } catch (error) {
-        if (!abortController.signal.aborted) {
-          console.error("Failed to update models:", error);
-          window.showErrorMessage(
-            "Failed to update models. Please try again later.",
-          );
-        }
+      const modelsToUpdate = await Promise.all(
+        modelsToCheck.map(async (model) => {
+          try {
+            const modelStatus = await this.ollamaServer.getModelStatus(
+              model,
+              true,
+            );
+            return modelStatus === ModelStatus.stale ||
+              modelStatus === ModelStatus.missing //missing if the extension was updated and configured a new model id
+              ? model
+              : null;
+          } catch (error) {
+            console.error(`Failed to check status for model ${model}:`, error);
+            return null;
+          }
+        }),
+      ).then((results) =>
+        results.filter((model): model is string => model !== null),
+      );
+
+      if (modelsToUpdate.length === 0) {
+        console.log("No models to update");
+        return;
       }
-    },
-  );
-}
 
-async function configureModelUpdateCheck(state: UpdaterState): Promise<void> {
-  const checkUpdates = workspace
-    .getConfiguration(EXTENSION_NAME)
-    .get<boolean>("checkModelUpdates", true);
+      const downloadSize = (
+        await Promise.all(
+          modelsToUpdate.map(async (model) => {
+            const modelInfo = await this.ollamaServer.getModelInfo(model);
+            return modelInfo?.size || 0;
+          }),
+        )
+      ).reduce((total, modelSize) => total + modelSize, 0);
 
-  if (checkUpdates) {
-    if (!state.updateInterval) {
-      await enableModelUpdateCheck(state);
+      console.log("Models requiring update:", modelsToUpdate);
+      const userChoice = await window.showInformationMessage(
+        `Granite.Code model updates available. Update requires ${formatSize(downloadSize)} download.`,
+        USER_OPTIONS.UPDATE,
+        USER_OPTIONS.CANCEL,
+      );
+
+      if (userChoice === USER_OPTIONS.UPDATE) {
+        await this.updateModels(modelsToUpdate);
+      }
+    } catch (error) {
+      console.error("Error during model update check:", error);
     }
-  } else {
-    disableModelUpdateCheck(state);
+  }
+
+  private async updateModels(models: string[]): Promise<void> {
+    return window.withProgress(
+      {
+        location: ProgressLocation.Notification,
+        title: "Updating Granite.Code models",
+        cancellable: true,
+      },
+      async (progress, token) => {
+        const abortController = new AbortController();
+        token.onCancellationRequested(() => {
+          console.log("Model update cancelled by user");
+          abortController.abort();
+        });
+        const progressWrapper = (data: ProgressData): void => {
+          const completed = data.completed ?? 0;
+          const total = data.total ?? 0;
+          let message = data.status;
+
+          if (total > 0) {
+            const progressPercent = Math.round((completed / total) * 100);
+            message = `${message} ${progressPercent}%`;
+          }
+          const increment = data.increment ? (data.increment / total) * 100 : 0;
+          progress.report({ increment, message });
+        };
+
+        try {
+          await this.ollamaServer.pullModels(
+            models,
+            abortController.signal,
+            progressWrapper,
+          );
+        } catch (error) {
+          if (!abortController.signal.aborted) {
+            console.error("Failed to update models:", error);
+            window.showErrorMessage(
+              "Failed to update models. Please try again later.",
+            );
+          }
+        }
+      },
+    );
+  }
+
+  async configureModelUpdateCheck(): Promise<void> {
+    const checkUpdates = workspace
+      .getConfiguration(EXTENSION_NAME)
+      .get<boolean>("checkModelUpdates", true);
+
+    if (checkUpdates) {
+      await this.enableModelUpdateCheck();
+    } else {
+      this.disableModelUpdateCheck();
+    }
+  }
+
+  public dispose(): void {
+    this.disableModelUpdateCheck();
+    this.ollamaServer.dispose();
   }
 }
 
-export async function registerModelUpdateProvider(
+export async function registerModelUpdater(
   context: ExtensionContext,
 ): Promise<void> {
-  const state: UpdaterState = {
-    ollamaServer: new OllamaServer(context),
-    checkNow: () => {
-      //Don't check now if onboarding is not completed
-      return !context.globalState.get(SHOW_GRANITE_ONBOARDING_CARD_KEY, true);
-    },
-  };
-
+  const modelUpdater = new ModelUpdater(context);
   context.subscriptions.push(
     workspace.onDidChangeConfiguration(async (e) => {
       if (e.affectsConfiguration(`${EXTENSION_NAME}.checkModelUpdates`)) {
-        await configureModelUpdateCheck(state);
+        await modelUpdater.configureModelUpdateCheck();
       }
     }),
   );
-  await configureModelUpdateCheck(state);
+  context.subscriptions.push(modelUpdater);
+  await modelUpdater.configureModelUpdateCheck();
 }

--- a/extensions/vscode/src/granite/panels/setupGranitePage.ts
+++ b/extensions/vscode/src/granite/panels/setupGranitePage.ts
@@ -1,5 +1,11 @@
+import { LocalModelSize } from "core";
 import { ConfigHandler } from "core/config/ConfigHandler";
+import {
+  DEFAULT_MODEL_GRANITE_LARGE,
+  DEFAULT_MODEL_GRANITE_SMALL,
+} from "core/config/default";
 import { EXTENSION_NAME } from "core/control-plane/env";
+import { SHOW_GRANITE_ONBOARDING_CARD_KEY } from "core/granite/commons/constants";
 import { DOWNLOADABLE_MODELS } from "core/granite/commons/modelRequirements";
 import { ProgressData } from "core/granite/commons/progressData";
 import { ModelStatus, ServerStatus } from "core/granite/commons/statuses";
@@ -22,8 +28,6 @@ import {
   workspace,
 } from "vscode";
 
-import { LocalModelSize } from "core";
-import { SHOW_GRANITE_ONBOARDING_CARD_KEY } from "core/granite/commons/constants";
 import { VsCodeWebviewProtocol } from "../../webviewProtocol";
 import { OllamaServer } from "../ollama/ollamaServer";
 import { CancellationController } from "../utils/cancellationController";
@@ -386,8 +390,13 @@ export class SetupGranitePage {
     this._disposables.push(this.modelInstallCanceller);
     try {
       this.wizardState.selectedModelSize = modelSize;
+      const graniteModel =
+        modelSize === "large"
+          ? DEFAULT_MODEL_GRANITE_LARGE
+          : DEFAULT_MODEL_GRANITE_SMALL;
+
       const result = await this.server.pullModels(
-        modelSize,
+        [graniteModel.model, "nomic-embed-text:latest"],
         this.modelInstallCanceller.signal,
         reportProgress,
       );

--- a/extensions/vscode/src/granite/utils/extensionUtils.ts
+++ b/extensions/vscode/src/granite/utils/extensionUtils.ts
@@ -1,0 +1,13 @@
+import { isTestMode, SHOW_GRANITE_ONBOARDING_CARD_KEY } from "core/granite/commons/constants";
+import { ExtensionContext } from "vscode";
+
+/**
+ * Returns true if the Granite onboarding has been completed. Always returns true in test mode.
+ *
+ * @param context The extension context
+ * @returns True if the Granite onboarding has been completed. Always returns true in test mode.
+ */
+export function isGraniteOnboardingComplete(context: ExtensionContext): boolean {
+    const showOnboarding = context.globalState.get<boolean>(SHOW_GRANITE_ONBOARDING_CARD_KEY, true);
+    return (!showOnboarding || isTestMode === true);
+}


### PR DESCRIPTION
Fixes https://github.com/Granite-Code/granite-code/issues/4

- adds a new continue.checkModelUpdates preference in package.json
- sets a 24h interval to check if Granite.Code model updates are available (including nomic-embed-text).
- the check is also triggered:
   * on extension startup, if Granite.Code onboarding was previously completed
   * when continue.checkModelUpdates is set to true
- checks the staleness of a model by computing the manifest digest on the ollama registry, compares it to the one currently announced from ollama's api/tags endpoint
- missing models also trigger an update notification. Useful if a new Granite.Code version was installed, which referenced different model ids
- if updates are available a notification is shown to the user with 3 choices:
   * Update: pulls the model updates
   * Cancel: ignores this notification until the next check
  

## Screenshots
<img width="456" alt="Screenshot 2025-03-19 at 17 20 36" src="https://github.com/user-attachments/assets/d8e42169-dee8-4723-92f7-81779456da98" />

<img width="994" alt="Screenshot 2025-03-19 at 17 21 21" src="https://github.com/user-attachments/assets/fdd30497-76cf-41c3-9193-918e913ce94d" />


## Testing instructions

- delete your granite.code model, e.g. ` ollama rm nomic-embed-text granite3.2:2b`
- start Granite.Code
- notification pops up
