### PR TITLE
Remove (or reremove) elements that we don't want

### DIFF
--- a/gui/src/components/PageHeader.tsx
+++ b/gui/src/components/PageHeader.tsx
@@ -1,5 +1,4 @@
 import { ArrowLeftIcon } from "@heroicons/react/24/outline";
-import { AccountButton } from "../pages/config/AccountButton";
 
 export interface PageHeaderProps {
   onTitleClick?: () => void;
@@ -34,7 +33,6 @@ export default function PageHeader({
                 {title}
               </span>
             </div>
-            <AccountButton />
           </>
         )}
       </div>

--- a/gui/src/pages/config/index.tsx
+++ b/gui/src/pages/config/index.tsx
@@ -192,7 +192,7 @@ function ConfigPage() {
               )
             ) : (
               // Continue for teams: show org text
-              <div>You are using Continue for Teams</div>
+              false && <div>You are using Continue for Teams</div>
             )}
 
             {profiles && profiles.length > 1 ? (

--- a/gui/src/pages/config/index.tsx
+++ b/gui/src/pages/config/index.tsx
@@ -195,7 +195,7 @@ function ConfigPage() {
               <div>You are using Continue for Teams</div>
             )}
 
-            {profiles ? (
+            {profiles && profiles.length > 1 ? (
               <>
                 <div className="flex flex-col gap-1.5">
                   <div className="flex items-center justify-between gap-1.5 text-sm">


### PR DESCRIPTION
This patch disables some things that we don't want that appeared with the latest merge of origin/main

 - The profile selector
-  The Sign In button in the page header
 - A "You are using Continue for teams" message