### PR TITLE
Redo config and customization

### DIFF
--- a/core/config/default.ts
+++ b/core/config/default.ts
@@ -1,9 +1,10 @@
-import { ConfigYaml } from "@continuedev/config-yaml";
-import { ModelDescription } from "..";
+import {
+  AssistantUnrolled,
+  ConfigYaml,
+  ModelConfig,
+} from "@continuedev/config-yaml";
 
-export const defaultContextProvidersVsCode: NonNullable<
-  ConfigYaml["context"]
->[number][] = [
+export const defaultContextProvidersVsCode = [
   { provider: "code" },
   { provider: "docs" },
   { provider: "diff" },
@@ -13,9 +14,7 @@ export const defaultContextProvidersVsCode: NonNullable<
   { provider: "codebase" },
 ];
 
-export const defaultContextProvidersJetBrains: NonNullable<
-  ConfigYaml["context"]
->[number][] = [
+export const defaultContextProvidersJetBrains = [
   { provider: "diff" },
   { provider: "folder" },
   { provider: "codebase" },
@@ -39,33 +38,46 @@ export const defaultConfigJetBrains: ConfigYaml = {
 
 const DEFAULT_CONTEXT_LENGTH = 8192;
 
-const BASE_GRANITE_CONFIG: Partial<ModelDescription> = {
-  contextLength: DEFAULT_CONTEXT_LENGTH,
-  completionOptions: {
+const BASE_GRANITE_CONFIG: Partial<ModelConfig> = {
+  defaultCompletionOptions: {
+    contextLength: DEFAULT_CONTEXT_LENGTH,
     maxTokens: DEFAULT_CONTEXT_LENGTH / 4,
     temperature: 0,
-    topP: 0.9,
-    topK: 40,
-    presencePenalty: 0.0,
-    frequencyPenalty: 0.1,
   },
-  systemMessage: `\
-You are Granite, an AI language model developed by IBM. \
-You are a cautious assistant. You carefully follow instructions. \
-You are helpful and harmless and you follow ethical guidelines and promote positive behavior.
-`,
+  roles: ["apply", "autocomplete", "chat", "edit", "summarize"],
 };
 
-export const DEFAULT_MODEL_GRANITE_SMALL: ModelDescription = {
-  title: "granite3.2:2b",
+export const DEFAULT_MODEL_GRANITE_SMALL: ModelConfig = {
+  name: "granite3.2:2b",
   provider: "ollama",
   model: "granite3.2:2b",
   ...BASE_GRANITE_CONFIG,
 };
 
-export const DEFAULT_MODEL_GRANITE_LARGE: ModelDescription = {
-  title: "granite3.2:8b",
+export const DEFAULT_MODEL_GRANITE_LARGE: ModelConfig = {
+  name: "granite3.2:8b",
   provider: "ollama",
   model: "granite3.2:8b",
   ...BASE_GRANITE_CONFIG,
+};
+
+export const DEFAULT_GRANITE_EMBEDDING_MODEL: ModelConfig = {
+  name: "nomic-embed-text",
+  provider: "ollama",
+  model: "nomic-embed-text:latest",
+  roles: ["embed"],
+};
+
+export const defaultConfigGraniteLarge: Required<
+  Pick<AssistantUnrolled, "models" | "context">
+> = {
+  models: [DEFAULT_MODEL_GRANITE_LARGE, DEFAULT_GRANITE_EMBEDDING_MODEL],
+  context: defaultContextProvidersVsCode,
+};
+
+export const defaultConfigGraniteSmall: Required<
+  Pick<AssistantUnrolled, "models" | "context">
+> = {
+  models: [DEFAULT_MODEL_GRANITE_SMALL, DEFAULT_GRANITE_EMBEDDING_MODEL],
+  context: defaultContextProvidersVsCode,
 };

--- a/core/config/yaml/loadYaml.ts
+++ b/core/config/yaml/loadYaml.ts
@@ -31,7 +31,6 @@ import { contextProviderClassFromName } from "../../context/providers/index";
 import { ControlPlaneClient } from "../../control-plane/client";
 import { allEmbeddingsProviders } from "../../indexing/allEmbeddingsProviders";
 import FreeTrial from "../../llm/llms/FreeTrial";
-import TransformersJsEmbeddingsProvider from "../../llm/llms/TransformersJsEmbeddingsProvider";
 import { slashCommandFromPromptFileV1 } from "../../promptFiles/v1/slashCommandFromPromptFile";
 import { getAllPromptFiles } from "../../promptFiles/v2/getPromptFiles";
 import { allTools } from "../../tools";
@@ -318,6 +317,8 @@ async function configYamlToContinueConfig(
     }
   }
 
+  /*
+  // Granite.Code: we're using nomic on ollama, not transformers
   // Add transformers js to the embed models in vs code if not already added
   if (
     ideInfo.ideType === "vscode" &&
@@ -329,6 +330,7 @@ async function configYamlToContinueConfig(
       new TransformersJsEmbeddingsProvider(),
     );
   }
+  */
 
   if (allowFreeTrial) {
     // Obtain auth token (iff free trial being used)

--- a/core/util/paths.ts
+++ b/core/util/paths.ts
@@ -99,7 +99,7 @@ export function getConfigJsonPath(): string {
 
 export function getConfigYamlPath(ideType?: IdeType): string {
   const p = path.join(getContinueGlobalPath(), "config.yaml");
-  if (!fs.existsSync(p) && !fs.existsSync(getConfigJsonPath())) {
+  if (!fs.existsSync(p) /* && !fs.existsSync(getConfigJsonPath()) */) {
     if (ideType === "jetbrains") {
       fs.writeFileSync(p, YAML.stringify(defaultConfigJetBrains));
     } else {

--- a/gui/src/components/mainInput/Lump/sections/ModelsSection.tsx
+++ b/gui/src/components/mainInput/Lump/sections/ModelsSection.tsx
@@ -1,8 +1,11 @@
 import { ModelRole } from "@continuedev/config-yaml";
+import { PlusIcon } from "@heroicons/react/24/outline";
 import { ModelDescription } from "core";
 import { useContext } from "react";
+import { GhostButton } from "../../..";
 import { useAuth } from "../../../../context/Auth";
 import { IdeMessengerContext } from "../../../../context/IdeMessenger";
+import AddModelForm from "../../../../forms/AddModelForm";
 import ModelRoleSelector from "../../../../pages/config/ModelRoleSelector";
 import { useAppDispatch, useAppSelector } from "../../../../redux/hooks";
 import {
@@ -10,8 +13,11 @@ import {
   setDefaultModel,
   updateConfig,
 } from "../../../../redux/slices/configSlice";
-import { isJetBrains } from "../../../../util";
-import { ExploreBlocksButton } from "./ExploreBlocksButton";
+import {
+  setDialogMessage,
+  setShowDialog,
+} from "../../../../redux/slices/uiSlice";
+import { fontSize, isJetBrains } from "../../../../util";
 
 export function ModelsSection() {
   const { selectedProfile } = useAuth();
@@ -49,6 +55,19 @@ export function ModelsSection() {
       return;
     }
     dispatch(setDefaultModel({ title: model.title }));
+  }
+
+  function handleAddModel() {
+    dispatch(setShowDialog(true));
+    dispatch(
+      setDialogMessage(
+        <AddModelForm
+          onDone={() => {
+            dispatch(setShowDialog(false));
+          }}
+        />,
+      ),
+    );
   }
 
   return (
@@ -107,8 +126,21 @@ export function ModelsSection() {
           selectedModel={config.selectedModelByRole.rerank}
           onSelect={(model) => handleRoleUpdate("rerank", model)}
         />
+        <GhostButton
+          className="w-full cursor-pointer rounded px-2 text-center text-gray-400 hover:text-gray-300"
+          style={{
+            fontSize: fontSize(-3),
+          }}
+          onClick={(e) => {
+            e.preventDefault();
+            handleAddModel();
+          }}
+        >
+          <div className="flex items-center justify-center gap-1">
+            <PlusIcon className="h-3 w-3" /> Add Models
+          </div>
+        </GhostButton>
       </div>
-      <ExploreBlocksButton blockType={"models"} />
     </div>
   );
 }

--- a/gui/src/components/modelSelection/ModelSelect.tsx
+++ b/gui/src/components/modelSelection/ModelSelect.tsx
@@ -2,8 +2,7 @@ import {
   CheckIcon,
   ChevronDownIcon,
   Cog6ToothIcon,
-  CubeIcon,
-  PlusIcon,
+  CubeIcon
 } from "@heroicons/react/24/outline";
 import { useContext, useEffect, useRef, useState } from "react";
 import { useDispatch } from "react-redux";
@@ -194,7 +193,7 @@ function ModelSelect() {
     );
   }
 
-  return (
+  return sortedOptions.length > 1 && (
     // <span className="line-clamp-1">Hiad sfasdfasdf asdfasdf</span>
     <Listbox
       onChange={async (val: string) => {
@@ -230,21 +229,6 @@ function ModelSelect() {
           </div>
 
           <div className="">
-            {selectedProfile?.profileType === "local" && (
-              <>
-                <ListboxOption
-                  key={options.length}
-                  onClick={onClickAddModel}
-                  value={"addModel" as any}
-                >
-                  <div className="flex items-center py-0.5">
-                    <PlusIcon className="mr-2 h-3 w-3" />
-                    Add Chat model
-                  </div>
-                </ListboxOption>
-              </>
-            )}
-
             <span className="block px-2 py-1" style={{ color: lightGray }}>
               {getMetaKeyLabel()}' to toggle model
             </span>

--- a/gui/src/components/modelSelection/platform/AssistantSelect.tsx
+++ b/gui/src/components/modelSelection/platform/AssistantSelect.tsx
@@ -213,7 +213,7 @@ export default function AssistantSelect() {
     );
   }
 
-  return (
+  return profiles && profiles.length > 1 && (
     <Listbox>
       <div className="sm:max-w-4/5 relative flex">
         <ListboxButton
@@ -261,17 +261,6 @@ export default function AssistantSelect() {
                   backgroundColor: vscCommandCenterInactiveBorder,
                 }}
               />
-
-              <ListboxOption
-                value={"new-assistant"}
-                fontSizeModifier={-2}
-                onClick={session ? onNewAssistant : () => login(false)}
-              >
-                <div className="flex flex-row items-center gap-2">
-                  <PlusIcon className="h-4 w-4 flex-shrink-0" />
-                  New Assistant
-                </div>
-              </ListboxOption>
 
               <div
                 className="my-0 h-[0.5px]"


### PR DESCRIPTION
A grab-bag of changes to get us back to a similar state after merging the new UI

 * Merge our configuration into config.yaml, not config.json; config.json is now entirely ignored
 * Update our granite configuration to not set parameters that don't matter with T=0 (top_p, top_k) and not set `frequencyPenalty: 0.1` which is no longer supported in config.yaml - where that came from is unclear, and there's no standard recommendation to use it with Granite.
 * Hide model selection and assistant selection dropdowns unless there is more than one model/assistant
 * Remove the "New Assistant" button that takes you to hub.continue.dev
 * Tweak adding chat models so that it can be done from the models section of the new "lump toolbar"
 * Don't auto-add transformers.js embedding model - we don't need it

This roughly corresponds to a discussion I had with @allanday about how we should adjust to the new UI