### PR TITLE
Disable agent mode

### DIFF
--- a/core/llm/toolSupport.ts
+++ b/core/llm/toolSupport.ts
@@ -104,8 +104,12 @@ export const PROVIDER_TOOL_SUPPORT: Record<
         "athene-v2",
         "nemotron",
         "llama3-groq",
-        "granite3",
-        "granite-3",
+        // Granite.Code: while the Granite models support tool calling,
+        // the results are not currently good enough to enable agent mode.
+        // This can be overriden in config.yaml by specifying
+        //   capabilities: [tool_use]
+        // "granite3",
+        // "granite-3",
         "aya-expanse",
         "firefunction-v2",
         "mistral",

--- a/gui/src/components/mainInput/Lump/BlockSettingsTopToolbar.tsx
+++ b/gui/src/components/mainInput/Lump/BlockSettingsTopToolbar.tsx
@@ -8,8 +8,10 @@ import {
   Squares2X2Icon,
   WrenchScrewdriverIcon,
 } from "@heroicons/react/24/outline";
+import { modelSupportsTools } from "core/llm/autodetect";
 import { vscBadgeBackground, vscBadgeForeground } from "../..";
 import { useAppDispatch, useAppSelector } from "../../../redux/hooks";
+import { selectDefaultModel } from "../../../redux/slices/configSlice";
 import { toggleBlockSettingsToolbar } from "../../../redux/slices/uiSlice";
 import { fontSize } from "../../../util";
 import AssistantSelect from "../../modelSelection/platform/AssistantSelect";
@@ -97,6 +99,11 @@ export function BlockSettingsTopToolbar(props: BlockSettingsTopToolbarProps) {
     }
     dispatch(toggleBlockSettingsToolbar());
   };
+  const selectedModel = useAppSelector(selectDefaultModel);
+  const agentModeSupported = selectedModel && modelSupportsTools(selectedModel);
+  const availableSections = sections.filter(
+    (s) => agentModeSupported || (s.id != "tools" && s.id != "mcp"),
+  );
 
   return (
     <div className="flex w-full items-center justify-between">
@@ -113,7 +120,7 @@ export function BlockSettingsTopToolbar(props: BlockSettingsTopToolbarProps) {
           style={{ width: isExpanded ? `160px` : "0px" }}
         >
           <div className="flex">
-            {sections.map((section) => (
+            {availableSections.map((section) => (
               <BlockSettingsToolbarIcon
                 key={section.id}
                 icon={section.icon}

--- a/gui/src/components/mainInput/Lump/sections/ModelsSection.tsx
+++ b/gui/src/components/mainInput/Lump/sections/ModelsSection.tsx
@@ -1,8 +1,6 @@
 import { ModelRole } from "@continuedev/config-yaml";
-import { PlusIcon } from "@heroicons/react/24/outline";
 import { ModelDescription } from "core";
 import { useContext } from "react";
-import { GhostButton } from "../../..";
 import { useAuth } from "../../../../context/Auth";
 import { IdeMessengerContext } from "../../../../context/IdeMessenger";
 import AddModelForm from "../../../../forms/AddModelForm";
@@ -17,7 +15,7 @@ import {
   setDialogMessage,
   setShowDialog,
 } from "../../../../redux/slices/uiSlice";
-import { fontSize, isJetBrains } from "../../../../util";
+import { isJetBrains } from "../../../../util";
 
 export function ModelsSection() {
   const { selectedProfile } = useAuth();
@@ -119,13 +117,14 @@ export function ModelsSection() {
           selectedModel={config.selectedModelByRole.embed}
           onSelect={(model) => handleRoleUpdate("embed", model)}
         />
-        <ModelRoleSelector
+        {config.modelsByRole.rerank.length > 0 && <ModelRoleSelector
           displayName="Rerank"
           description="Used for reranking results from the @codebase and @docs context providers"
           models={config.modelsByRole.rerank}
           selectedModel={config.selectedModelByRole.rerank}
           onSelect={(model) => handleRoleUpdate("rerank", model)}
-        />
+        />}
+        {/*
         <GhostButton
           className="w-full cursor-pointer rounded px-2 text-center text-gray-400 hover:text-gray-300"
           style={{
@@ -140,6 +139,7 @@ export function ModelsSection() {
             <PlusIcon className="h-3 w-3" /> Add Models
           </div>
         </GhostButton>
+        */}
       </div>
     </div>
   );

--- a/gui/src/components/modelSelection/ModeSelect.tsx
+++ b/gui/src/components/modelSelection/ModeSelect.tsx
@@ -127,6 +127,7 @@ function ModeSelect() {
           />
         </ListboxButton>
         <ListboxOptions className="min-w-32 max-w-48">
+          {agentModeSupported &&
           <ListboxOption value="agent" disabled={!agentModeSupported}>
             <div className="flex flex-row items-center gap-1.5">
               <SparklesIcon className="h-3 w-3" />
@@ -134,7 +135,7 @@ function ModeSelect() {
             </div>
             {mode === "agent" && <CheckIcon className="ml-auto h-3 w-3" />}
             {!agentModeSupported && <span> (Not supported)</span>}
-          </ListboxOption>
+          </ListboxOption>}
 
           <ListboxOption value="chat">
             <div className="flex flex-row items-center gap-1.5">

--- a/gui/src/components/modelSelection/platform/AssistantSelect.tsx
+++ b/gui/src/components/modelSelection/platform/AssistantSelect.tsx
@@ -3,8 +3,7 @@ import {
   BuildingOfficeIcon,
   ChevronDownIcon,
   Cog6ToothIcon,
-  ExclamationTriangleIcon,
-  PlusIcon,
+  ExclamationTriangleIcon
 } from "@heroicons/react/24/outline";
 import { useContext, useEffect, useMemo, useRef, useState } from "react";
 import { useAuth } from "../../../context/Auth";
@@ -192,6 +191,8 @@ export default function AssistantSelect() {
   const smallFont = useFontSize(-3);
 
   if (!selectedProfile) {
+    return null;
+/*
     return (
       <div
         onClick={() => {
@@ -211,6 +212,7 @@ export default function AssistantSelect() {
         </span>
       </div>
     );
+*/
   }
 
   return profiles && profiles.length > 1 && (


### PR DESCRIPTION
## Description
Follow up on #22 

- disables Tools, MCP sections from top toolbar of chat view
- disables Agent mode support since tools are not supported
- disables the ability to add new Models
- hides reranker model selection 
- disables the Assistant component entirely (was still briefly showing the Create a new assistant message)

## Screenshots

<img width="358" alt="Screenshot 2025-04-04 at 12 14 16" src="https://github.com/user-attachments/assets/a7ecb8d2-62ac-4b4b-ab5f-db3bd0687cbc" />
