### PR TITLE
Disable Granite.Code when launching in Dev mode

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -14,6 +14,7 @@
         // Pass a directory to manually test in
         "${workspaceFolder}/manual-testing-sandbox",
         "${workspaceFolder}/manual-testing-sandbox/test.js",
+        "--disable-extension=redhat.granitecode",
         "--extensionDevelopmentPath=${workspaceFolder}/extensions/vscode"
       ],
       "pauseForSourceMap": false,
@@ -83,6 +84,7 @@
       "args": [
         // Pass a directory to run tests in
         "${workspaceFolder}/extensions/vscode/manual-testing-sandbox",
+        "--disable-extension=redhat.granitecode",
         "--extensionDevelopmentPath=${workspaceFolder}/extensions/vscode",
         "--extensionTestsPath=${workspaceFolder}/extensions/vscode/out/test/runner/mochaRunner"
       ],


### PR DESCRIPTION
Disables the Granite.Code extension when launching in Dev mode.
If needed, we could add another launch config where Granite.Code is not disabled.

Fixes https://github.com/Granite-Code/granite-code/issues/87