### PR TITLE
setupGranitePage: set vscode global variable

### DIFF
--- a/extensions/vscode/src/granite/panels/setupGranitePage.ts
+++ b/extensions/vscode/src/granite/panels/setupGranitePage.ts
@@ -232,6 +232,7 @@ export class SetupGranitePage {
           <meta charset="UTF-8" />
           <meta name="viewport" content="width=device-width, initial-scale=1.0" />
           <meta http-equiv="Content-Security-Policy" content="default-src 'self'; style-src ${webview.cspSource} ${devStyleSrc} 'unsafe-inline'; script-src 'nonce-${nonce}'; connect-src ${devConnectSrc} 'self'; img-src https: ${webview.cspSource} data:">
+          <script nonce="${nonce}">const vscode = acquireVsCodeApi();</script>
           <link rel="stylesheet" type="text/css" href="${stylesUri}">
           <title>Granite Models</title>
           </head>


### PR DESCRIPTION
With the latest merge of upstream, vscode-webview  was removed from upstream, and I did the same for the Granite Setup wizard, but forgot to actually add the necessary code to set the vscode global variable.
