### PR TITLE
Improve ollama status polling

### DIFF
--- a/extensions/vscode/src/granite/ollama/ollamaServer.ts
+++ b/extensions/vscode/src/granite/ollama/ollamaServer.ts
@@ -25,6 +25,8 @@ export class OllamaServer implements IModelServer, Disposable {
   protected installingModels = new Set<string>();
   private modelInfoPromises: Map<string, Promise<ModelInfo | undefined>> = new Map();
   private modelInfoResults: Map<string, ModelInfo | undefined> = new Map();
+  private cachedTags?: { timestamp: number, tags: Promise<any[]> };
+
   constructor(private context: ExtensionContext, private name: string = "Ollama", private serverUrl = "http://localhost:11434") { }
 
   dispose(): void {
@@ -32,6 +34,7 @@ export class OllamaServer implements IModelServer, Disposable {
     this.installingModels.clear();
     this.modelInfoPromises.clear();
     this.modelInfoResults.clear();
+    this.cachedTags = undefined;
   }
 
   getName(): string {
@@ -254,15 +257,13 @@ export class OllamaServer implements IModelServer, Disposable {
     return status;
   }
 
-  private cachedTags?: { timestamp: number, tags: any[] };
-
   async getTags(): Promise<any[]> {
     if (!this.cachedTags || (Date.now() - this.cachedTags.timestamp) > 100) {//cache for 100ms
       this.cachedTags = {
         timestamp: Date.now(),
-        tags: await this._getTags(),
+        tags: this._getTags()
       };
-    }
+    };
     return this.cachedTags.tags;
   }
 

--- a/extensions/vscode/src/granite/panels/setupGranitePage.ts
+++ b/extensions/vscode/src/granite/panels/setupGranitePage.ts
@@ -74,7 +74,7 @@ export class SetupGranitePage {
       : ({ stepStatuses: [false, false, false] } as WizardState);
 
     // Set up dispose handler with confirmation dialog
-    this._panel.onDidDispose(
+    this._disposables.push(this._panel.onDidDispose(
       async () => {
         // Verify setup is complete by checking if ollama and the models are configured
         const isComplete =
@@ -106,7 +106,17 @@ export class SetupGranitePage {
       },
       null,
       this._disposables,
-    );
+    ));
+
+    // Add visibility change detection in the webview panel
+    this._disposables.push(this._panel.onDidChangeViewState((event) => {
+      this._panel.webview.postMessage({
+        command: "visibilityChange",
+        data: {
+          isVisible: event.webviewPanel.visible
+        }
+      });
+    }));
 
     // Set the HTML content for the webview panel
     this._panel.webview.html = this._getWebviewContent(

--- a/gui/src/granite/GraniteWizard.tsx
+++ b/gui/src/granite/GraniteWizard.tsx
@@ -90,6 +90,8 @@ interface WizardContextProps {
   setOllamaInstallationError: React.Dispatch<
     React.SetStateAction<string | undefined>
   >;
+  isVisible: boolean;
+  setVisible: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
 const WizardContext = createContext<WizardContextProps | undefined>(undefined);
@@ -144,6 +146,7 @@ export const WizardProvider: React.FC<WizardProviderProps> = ({ children }) => {
     "idle" | "downloading" | "complete"
   >("idle");
   const [isOffline, setIsOffline] = useState(false);
+  const [isVisible, setVisible] = useState(true);
 
   return (
     <WizardContext.Provider
@@ -178,6 +181,8 @@ export const WizardProvider: React.FC<WizardProviderProps> = ({ children }) => {
         setIsOffline,
         modelInstallationError,
         setModelInstallationError,
+        isVisible,
+        setVisible,
       }}
     >
       {children}
@@ -621,19 +626,8 @@ export const GraniteWizard: React.FC = () => {
   );
 };
 
-function requestStatus(): void {
-  vscode.postMessage({
-    command: "fetchStatus",
-  });
-}
-
-function init(): void {
-  vscode.postMessage({
-    command: "init",
-  });
-}
-
 const WizardContent: React.FC = () => {
+
   const {
     currentStatus,
     setCurrentStatus,
@@ -653,13 +647,38 @@ const WizardContent: React.FC = () => {
     setOllamaInstallationProgress,
     setOllamaInstallationError,
     setStatusByModel,
+    isVisible,
+    setVisible,
   } = useWizardContext();
   const currentStatusRef = useRef(currentStatus);
+  const isVisibleRef = useRef(isVisible);
+
+  const requestStatus = () => {
+    if(!isVisibleRef.current) {
+      return;
+    }
+
+    vscode.postMessage({
+      command: "fetchStatus",
+    });
+  }
+
+  const init = () => {
+    vscode.postMessage({
+      command: "init",
+    });
+  }
+
 
   // Update ref when currentStatus changes
   useEffect(() => {
     currentStatusRef.current = currentStatus;
   }, [currentStatus]);
+
+  // Update ref when visibility changes
+  useEffect(() => {
+    isVisibleRef.current = isVisible;
+  }, [isVisible]);
 
   const REFETCH_MODELS_INTERVAL_MS = 1500;
 
@@ -672,6 +691,9 @@ const WizardContent: React.FC = () => {
       }
       const currStatus = currentStatusRef.current;
       switch (command) {
+        case "visibilityChange":
+          setVisible(payload.data.isVisible);
+          break;
         case "init": {
           const data = payload.data;
           setInstallationModes(data.installModes);


### PR DESCRIPTION
## Description

Ollama tags polling cache mechanism is completely borked, as 4 requests always make there way to ollama during polling, instead of just 1:

<img width="755" alt="Screenshot 2025-04-22 at 11 39 34" src="https://github.com/user-attachments/assets/f81a2046-484e-4193-936c-68e1b7393b29" />

After caching the getTags promise instead, we send only 1 query during polling:

<img width="757" alt="Screenshot 2025-04-22 at 11 37 12" src="https://github.com/user-attachments/assets/4698ac41-53ef-4aae-8189-45956b64ffe2" />

(The api/version calls are due to #25 also being applied when the screenshots were taken)

Additionally, Ollama status polling is disabled when the Granite wizard is not visible, so as not waste unnecessary CPU cycles.