### PR TITLE
Fix typo in link to granite code website, in granitecode_tutorial.py

### DIFF
--- a/extensions/vscode/granitecode_tutorial.py
+++ b/extensions/vscode/granitecode_tutorial.py
@@ -37,4 +37,4 @@ def sorting_algorithm(x):
 # Basic assertion for sorting_algorithm...
 
 
-# ——————————————————      Learn more at https://granite.code.dev/    ————————————————————————————————————————————— #
+# ——————————————————      Learn more at https://granitecode.ai/    ————————————————————————————————————————————— #


### PR DESCRIPTION
Use correct https://granitecode.ai/ link in granitecode_tutorial.py

Fixes https://github.com/Granite-Code/granite-code/issues/107