### PR TITLE
feat: use integer values in download progress

### DIFF
--- a/gui/src/granite/GraniteWizard.tsx
+++ b/gui/src/granite/GraniteWizard.tsx
@@ -354,7 +354,6 @@ const OllamaInstallStep: React.FC<StepProps> = (props) => {
             <VSCodeButton variant="secondary" onClick={cancelDownload}>
               Cancel
             </VSCodeButton>
-            not here
             <ProgressBlock progress={ollamaInstallationProgress} />
           </div>
         )}

--- a/gui/src/granite/ProgressBlock.tsx
+++ b/gui/src/granite/ProgressBlock.tsx
@@ -4,7 +4,7 @@ export const ProgressBlock: React.FC<{ progress: number }> = ({ progress }) => {
   return (
     <div className="flex items-center justify-end opacity-80">
       <span className="inline-block w-[55px] text-right tabular-nums">
-        {progress.toFixed(2)}%
+        {Math.floor(progress)}%
       </span>
       <span className="ml-1">complete</span>
     </div>


### PR DESCRIPTION
## Description

Show download progress in Granite Wizard using integer values. ProgressBlock.tsx is used for both Ollama and model downloads.

Fixes https://github.com/Granite-Code/granite-code/issues/109


https://github.com/user-attachments/assets/1a96a3a0-ca63-47d8-9289-daf192aec8bb

