### PR TITLE
fix(granite-wizard): hide script mode progress block on Linux

### DIFF
--- a/gui/src/granite/GraniteWizard.tsx
+++ b/gui/src/granite/GraniteWizard.tsx
@@ -354,15 +354,15 @@ const OllamaInstallStep: React.FC<StepProps> = (props) => {
 
         {currentStatus !== WizardStatus.downloadingOllama && serverButton}
 
-        {currentStatus === WizardStatus.downloadingOllama && (
-          <div className="mt-4 flex items-center gap-2">
-            <VSCodeButton variant="secondary" onClick={cancelDownload}>
-              Cancel
-            </VSCodeButton>
-            <ProgressBlock progress={ollamaInstallationProgress} />
-          </div>
-        )}
-
+        {currentStatus === WizardStatus.downloadingOllama &&
+          installationModes[0]?.id !== "script" && (
+            <div className="mt-4 flex items-center gap-2">
+              <VSCodeButton variant="secondary" onClick={cancelDownload}>
+                Cancel
+              </VSCodeButton>
+              <ProgressBlock progress={ollamaInstallationProgress} />
+            </div>
+          )}
         {!isDevspaces && installationModes.length > 0 && (
           <p className="text-sm text-[--vscode-editor-foreground]">
             If you prefer, you can also{" "}


### PR DESCRIPTION
hides the “0.00% complete” progress block when using script mode to avoid showing duplicate progress.

https://github.com/Granite-Code/granite-code/issues/114



![438267529-0c58642b-b943-456e-88c4-17e051a1b60b](https://github.com/user-attachments/assets/e10eb316-79cb-4cd5-8d92-dd46784affff)
