### PR TITLE
fix: do not use conditional hook in GraniteWizard.tsx

### DIFF
--- a/gui/src/granite/GraniteWizard.tsx
+++ b/gui/src/granite/GraniteWizard.tsx
@@ -274,6 +274,26 @@ const OllamaInstallStep: React.FC<StepProps> = (props) => {
   } = useWizardContext();
   const [systemErrors, setSystemErrors] = useState<string[] | undefined>();
   const serverStatus = serverState.status;
+  const hiddenLinkRef = useRef<HTMLAnchorElement>(null);
+
+  useEffect(() => {
+    //cancel download on error
+    if (ollamaInstallationError || isOffline) {
+      cancelDownload();
+    }
+  }, [ollamaInstallationError, isOffline]);
+
+  useEffect(() => {
+    const ollamaVersion = serverState.version;
+    const sysErrors = [];
+    if (isOllamaOutdated) {
+      sysErrors.push(
+        `Ollama v${MIN_OLLAMA_VERSION} is required. Version ${ollamaVersion} is detected`,
+      );
+    }
+    setSystemErrors(sysErrors);
+  }, [serverState.version]);
+
   const handleDownload = () => {
     setCurrentStatus(WizardStatus.downloadingOllama);
     vscode.postMessage({
@@ -295,26 +315,8 @@ const OllamaInstallStep: React.FC<StepProps> = (props) => {
     setOllamaInstallationProgress(0);
   };
 
-  useEffect(() => {
-    //cancel download on error
-    if (ollamaInstallationError || isOffline) {
-      cancelDownload();
-    }
-  }, [ollamaInstallationError, isOffline]);
 
-  useEffect(() => {
-    const ollamaVersion = serverState.version;
-    const sysErrors = [];
-    if (isOllamaOutdated) {
-      sysErrors.push(
-        `Ollama v${MIN_OLLAMA_VERSION} is required. Version ${ollamaVersion} is detected`,
-      );
-    }
-    setSystemErrors(sysErrors);
-  }, [serverState.version]);
-
-  const isDevspaces =
-    installationModes.length > 0 && installationModes[0].id === "devspaces";
+  const isDevspaces = installationModes.length > 0 && installationModes[0].id === "devspaces";
 
   let serverButton;
   if (
@@ -328,7 +330,6 @@ const OllamaInstallStep: React.FC<StepProps> = (props) => {
       </VSCodeButton>
     );
   } else if (isDevspaces) {
-    const hiddenLinkRef = useRef<HTMLAnchorElement>(null);
     const hiddenLink = // Trick to open the link directly, avoiding calling VS Code API, which would show a security warning
       (
         <a


### PR DESCRIPTION
## Description

Using a conditional `useRef` hook in OllamaInstallStep when running in DevSpaces is likely the cause of the wizard rendering issue (`Rendered more hooks than during the previous render.`) in ... DevSpaces (https://github.com/Granite-Code/granite-code/issues/116). 
This tentative fix makes the `useRef` hook unconditional. I also moved all other hooks before any other code for good measure.
I can't reproduce the issue in VS Code so I'll need to try it out in a browser and confirm this is the proper fix.

Fixes https://github.com/Granite-Code/granite-code/issues/116

