### PR TITLE
Replace copilot with granite.code

### DIFF
--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -591,6 +591,11 @@
           "id": "continue",
           "title": "Continue",
           "icon": "media/sidebar-icon.png"
+        },
+        {
+          "id": "graniteMoveChatDestination",
+          "title": "Chat",
+          "icon": "comment-discussion"
         }
       ],
       "panel": [

--- a/extensions/vscode/src/activation/activate.ts
+++ b/extensions/vscode/src/activation/activate.ts
@@ -5,6 +5,7 @@ import * as vscode from "vscode";
 import * as path from "path";
 import { VsCodeExtension } from "../extension/VsCodeExtension";
 import { registerModelUpdater } from "../granite/ollama/modelUpdater";
+import { replaceCopilotWithGraniteCode } from "../granite/utils/compatibilityUtils";
 import { isGraniteOnboardingComplete } from "../granite/utils/extensionUtils";
 import registerQuickFixProvider from "../lang-server/codeActions";
 import { getExtensionVersion } from "../util/util";
@@ -63,6 +64,7 @@ export async function activateExtension(context: vscode.ExtensionContext) {
   const initialActivationCompleted = context.globalState.get<boolean>(GRANITE_INITIAL_ACTIVATION_COMPLETED_KEY, false);
   if (!initialActivationCompleted) {
     if (!graniteOnboardingComplete) {
+      replaceCopilotWithGraniteCode()
       await vscode.commands.executeCommand("granite.setup");
     }
     await context.globalState.update(GRANITE_INITIAL_ACTIVATION_COMPLETED_KEY, true);

--- a/extensions/vscode/src/granite/utils/compatibilityUtils.ts
+++ b/extensions/vscode/src/granite/utils/compatibilityUtils.ts
@@ -53,3 +53,22 @@ export function setupExtensionCheck(
   });
   context.subscriptions.push(disposable);
 }
+
+/**
+ * Move Granite.Code into the default view container of Copilot, and move Copilot to our spare view container
+ */
+export function replaceCopilotWithGraniteCode() {
+  // Move Copilot to the spare activity sidebar container we created
+  vscode.commands
+    .executeCommand("vscode.moveViews", {
+      viewIds: ["workbench.panel.chat.view.copilot"],
+      destinationId: "workbench.view.extension.graniteMoveChatDestination",
+    })
+    .then(() => {
+      // Move Granite.Code to Copilot's default container
+      vscode.commands.executeCommand("vscode.moveViews", {
+        viewIds: ["continue.continueGUIView"],
+        destinationId: "workbench.panel.chat",
+      });
+    });
+}


### PR DESCRIPTION
## Description

There are two things in this PR:

1. Fix the import error due to the renaming. 
2. Add the feature that replace Copilot with Granite.Code. 

The details of the implementation are in the commit message.
https://github.com/Granite-Code/granite-code/issues/86

## Screenshots

https://github.com/user-attachments/assets/23b64839-c402-417f-84a5-3573285b5f04

## Testing instructions

Launch Granite.Code and see if it replaces Copilot.
