### PR TITLE
Fix: change mechanism of checking incompatible extensions

### DIFF
--- a/core/index.d.ts
+++ b/core/index.d.ts
@@ -1515,3 +1515,13 @@ export interface RuleWithSource {
   description?: string;
   ruleFile?: string;
 }
+
+export type ExtensionInfo = {
+  id: string;
+  name: string;
+};
+
+export type ExtensionConflictReport = {
+  currentExtension: ExtensionInfo;
+  conflictingExtensions: ExtensionInfo[];
+};

--- a/core/protocol/ideWebview.ts
+++ b/core/protocol/ideWebview.ts
@@ -4,6 +4,7 @@ import { ToWebviewFromIdeOrCoreProtocol } from "./webview";
 import type {
   ApplyState,
   CodeToEdit,
+  ExtensionConflictReport,
   MessageContent,
   RangeInFileWithContents,
 } from "../";
@@ -92,5 +93,5 @@ export type ToWebviewFromIdeProtocol = ToWebviewFromIdeOrCoreProtocol & {
   exitEditMode: [undefined, void];
   focusEdit: [undefined, void];
   setShowGraniteOnboardingCard: [boolean, void];
-  updateIncompatibleExtensions: [boolean, void];
+  updateIncompatibleExtensions: [ExtensionConflictReport | null, void];
 };

--- a/core/protocol/ideWebview.ts
+++ b/core/protocol/ideWebview.ts
@@ -23,6 +23,7 @@ export type ToIdeFromWebviewProtocol = ToIdeFromWebviewOrCoreProtocol & {
   overwriteFile: [{ filepath: string; prevFileContent: string | null }, void];
   showTutorial: [undefined, void];
   showSetupWizard: [undefined, void];
+  openExtensionSettings: [{extensions: string[]}, void];
   showFile: [{ filepath: string }, void];
   toggleDevTools: [undefined, void];
   reloadWindow: [undefined, void];

--- a/extensions/vscode/src/extension/VsCodeMessenger.ts
+++ b/extensions/vscode/src/extension/VsCodeMessenger.ts
@@ -152,6 +152,17 @@ export class VsCodeMessenger {
       await vscode.commands.executeCommand("granite.setup");
     });
 
+    this.onWebview("openExtensionSettings", async (msg) => {
+      const extensionIds = msg.data.extensions;
+      if (extensionIds.length === 0) {
+        //nothing to do
+        return;
+      }
+      await vscode.commands.executeCommand('workbench.extensions.search', extensionIds.join(" "));
+      // Open the 1st extension's page
+      await vscode.env.openExternal(vscode.Uri.parse(`vscode:extension/${extensionIds[0]}`));
+    });
+
     this.onWebview(
       "overwriteFile",
       async ({ data: { prevFileContent, filepath } }) => {

--- a/extensions/vscode/src/granite/utils/compatibilityUtils.ts
+++ b/extensions/vscode/src/granite/utils/compatibilityUtils.ts
@@ -1,17 +1,50 @@
 import * as vscode from "vscode";
 
+import { ExtensionConflictReport, ExtensionInfo } from "core";
 import type { VsCodeWebviewProtocol } from "../../webviewProtocol";
 
-const incompatibleExtensionIds = new Set(["Continue.continue"]);
-export function checkForIncompatibleExtensions(): boolean {
+const extensionNameLookup = new Map<string, string>([
+  ["redhat.granitecode" /* no-transform */, "Granite.Code" /* no-transform */],
+  ["Continue.continue" /* no-transform */, "Continue" /* no-transform */],
+]);
+
+// We have to omit this file while building, otherwise it would not work properly
+const incompatibleExtensionIds = new Set(extensionNameLookup.keys());
+let currentExtensionId = null;
+
+export function checkForIncompatibleExtensions(): ExtensionConflictReport | null {
   const extensions = vscode.extensions.all;
-  return extensions.some((e) => incompatibleExtensionIds.has(e.id));
+  const conflictingExtensions: ExtensionInfo[] = extensions
+    .filter((e) => incompatibleExtensionIds.has(e.id))
+    .map((e) => {
+      return {
+        id: e.id,
+        name: extensionNameLookup.get(e.id)!,
+      };
+    });
+
+  if (conflictingExtensions.length === 0) {
+    return null;
+  } else {
+    return {
+      currentExtension: {
+        id: currentExtensionId!,
+        name: extensionNameLookup.get(currentExtensionId!)!,
+      },
+      conflictingExtensions,
+    };
+  }
 }
 
 export function setupExtensionCheck(
   context: vscode.ExtensionContext,
   webviewMessenger: VsCodeWebviewProtocol,
 ) {
+  // Grab current extension id during activation
+  currentExtensionId = context.extension.id;
+  // Remove current extension id from the incompatible list
+  incompatibleExtensionIds.delete(currentExtensionId);
+
   // Register a listener to check compatibility for every newly enabled extension
   const disposable = vscode.extensions.onDidChange(() => {
     webviewMessenger.send(

--- a/gui/src/components/IncompatibleExtensionsOverlay.tsx
+++ b/gui/src/components/IncompatibleExtensionsOverlay.tsx
@@ -1,10 +1,42 @@
+import { ExtensionConflictReport, ExtensionInfo } from "core";
 import GraniteLogo from "../granite/GraniteLogo";
-function IncompatibleExtensionsOverlay() {
+
+function generateIncompatibleExtensionsString(
+  conflictingExtensions: ExtensionInfo[],
+): string {
+  switch (conflictingExtensions.length) {
+    case 0:
+      return "";
+    case 1:
+      return conflictingExtensions[0].name;
+    case 2:
+      return `${conflictingExtensions[0].name} and ${conflictingExtensions[1].name}`;
+    default:
+      const res = conflictingExtensions
+        .map((e) => e.name)
+        .slice(0, -1)
+        .join(", ");
+      return `${res}, and ${conflictingExtensions[conflictingExtensions.length - 1].name}`;
+  }
+}
+
+function IncompatibleExtensionsOverlay({
+  conflictingInfo,
+}: {
+  conflictingInfo: ExtensionConflictReport;
+}) {
+  // Currently, we only conflict with Continue
+  // This logic might need a tweak if we have more incompatible extensions in the future
+  const incompatibleExtensionNames = generateIncompatibleExtensionsString(
+    conflictingInfo.conflictingExtensions,
+  );
   return (
-    <div className="fade-in-overlay absolute z-50 flex flex-col h-full w-full items-center justify-center">
+    <div className="fade-in-overlay absolute z-50 flex h-full w-full flex-col items-center justify-center">
       <GraniteLogo alt="Granite.Code Logo" className="mb-2 h-24 w-24" />
-      <h1 className="mb-2 text-xl text-center p-2">Incompatible Extension Enabled</h1>
-      <p className="text-center p-2 font-medium text-gray-400">Granite.Code cannot be used while the Continue extension is enabled. Please disable Continue from the extension settings.</p>
+      <h1 className="mb-2 p-2 text-center text-xl">
+        Incompatible Extension Enabled
+      </h1>
+      <p className="p-2 text-center font-medium text-gray-400">{`${conflictingInfo.currentExtension.name} cannot be used while the ${incompatibleExtensionNames} ${conflictingInfo.conflictingExtensions.length > 1 ? "extensions are" : "extension is"} enabled. Please disable ${incompatibleExtensionNames} from the extension settings.`}</p>
     </div>
   );
 }

--- a/gui/src/components/IncompatibleExtensionsOverlay.tsx
+++ b/gui/src/components/IncompatibleExtensionsOverlay.tsx
@@ -1,22 +1,27 @@
 import { ExtensionConflictReport, ExtensionInfo } from "core";
+import React, { useContext } from "react";
+import { IdeMessengerContext } from "../context/IdeMessenger";
 import GraniteLogo from "../granite/GraniteLogo";
 
-function generateIncompatibleExtensionsString(
+function generateIncompatibleExtensionsBlock(
   conflictingExtensions: ExtensionInfo[],
-): string {
+): React.ReactNode {
+  const formatName = (name: string) => (
+    <span className="font-bold italic">{name}</span>
+  );
   switch (conflictingExtensions.length) {
     case 0:
-      return "";
+      return null;
     case 1:
-      return conflictingExtensions[0].name;
+      return formatName(conflictingExtensions[0].name);
     case 2:
-      return `${conflictingExtensions[0].name} and ${conflictingExtensions[1].name}`;
+      return <>{formatName(conflictingExtensions[0].name)} and {formatName(conflictingExtensions[1].name)}</>;
     default:
-      const res = conflictingExtensions
-        .map((e) => e.name)
-        .slice(0, -1)
-        .join(", ");
-      return `${res}, and ${conflictingExtensions[conflictingExtensions.length - 1].name}`;
+      return <>
+        {conflictingExtensions.slice(0, -1).map((e, i) => <React.Fragment key={e.name}>{i > 0 && ', '}{formatName(e.name)}</React.Fragment>)}
+        {", and "}
+        {formatName(conflictingExtensions[conflictingExtensions.length - 1].name)}
+      </>;
   }
 }
 
@@ -25,18 +30,28 @@ function IncompatibleExtensionsOverlay({
 }: {
   conflictingInfo: ExtensionConflictReport;
 }) {
-  // Currently, we only conflict with Continue
-  // This logic might need a tweak if we have more incompatible extensions in the future
-  const incompatibleExtensionNames = generateIncompatibleExtensionsString(
+  const ideMessenger = useContext(IdeMessengerContext);
+
+  const incompatibleExtensionNames = generateIncompatibleExtensionsBlock(
     conflictingInfo.conflictingExtensions,
   );
+
+  const openExtensionSettings = () => {
+    ideMessenger.post("openExtensionSettings", {
+      extensions: conflictingInfo.conflictingExtensions.map(
+        (extension) => extension.id,
+      ),
+    });
+  }
+
+
   return (
     <div className="fade-in-overlay absolute z-50 flex h-full w-full flex-col items-center justify-center">
       <GraniteLogo alt="Granite.Code Logo" className="mb-2 h-24 w-24" />
       <h1 className="mb-2 p-2 text-center text-xl">
         Incompatible Extension Enabled
       </h1>
-      <p className="p-2 text-center font-medium text-gray-400">{`${conflictingInfo.currentExtension.name} cannot be used while the ${incompatibleExtensionNames} ${conflictingInfo.conflictingExtensions.length > 1 ? "extensions are" : "extension is"} enabled. Please disable ${incompatibleExtensionNames} from the extension settings.`}</p>
+      <p className="p-2 text-center font-medium text-gray-400"><span className="font-bold italic">{conflictingInfo.currentExtension.name}</span> cannot be used while the {incompatibleExtensionNames} {conflictingInfo.conflictingExtensions.length > 1 ? "extensions are" : "extension is"} enabled. Please disable {incompatibleExtensionNames} from the extension <a onClick={openExtensionSettings} href="#">settings</a>.</p>
     </div>
   );
 }

--- a/gui/src/components/Layout.tsx
+++ b/gui/src/components/Layout.tsx
@@ -1,3 +1,4 @@
+import { ExtensionConflictReport } from "core";
 import { useContext, useEffect, useState } from "react";
 import { Outlet, useLocation, useNavigate } from "react-router-dom";
 import styled from "styled-components";
@@ -18,9 +19,9 @@ import { ROUTES } from "../util/navigation";
 import { FatalErrorIndicator } from "./config/FatalErrorNotice";
 import TextDialog from "./dialogs";
 import Footer from "./Footer";
+import IncompatibleExtensionsOverlay from "./IncompatibleExtensionsOverlay";
 import { LumpProvider } from "./mainInput/Lump/LumpContext";
 import { useMainEditor } from "./mainInput/TipTapEditor";
-import IncompatibleExtensionsOverlay from "./IncompatibleExtensionsOverlay";
 import OSRContextMenu from "./OSRContextMenu";
 import PostHogPageView from "./PosthogPageView";
 
@@ -52,8 +53,8 @@ const Layout = () => {
   const showDialog = useAppSelector((state) => state.ui.showDialog);
   const mode = useAppSelector((state) => state.session.mode);
 
-  const [conflictsWithOtherExtensions, setConflictsWithOtherExtensions] =
-    useState(false);
+  const [conflictingInfo, setConflictingInfo] =
+    useState<ExtensionConflictReport | null>(null);
 
   useWebviewListener(
     "newSession",
@@ -172,7 +173,7 @@ const Layout = () => {
   );
 
   useWebviewListener("updateIncompatibleExtensions", async (data) => {
-    setConflictsWithOtherExtensions(data);
+    setConflictingInfo(data);
   });
 
   useEffect(() => {
@@ -197,14 +198,16 @@ const Layout = () => {
 
   // Check if there are any incompatible extension enabled when the webview is on mount
   useEffect(() => {
-    ideMessenger.post("checkForIncompatibleExtensions", undefined)
+    ideMessenger.post("checkForIncompatibleExtensions", undefined);
   }, []);
 
   return showGraniteOnboardingCard ? (
     <GraniteOnboardingCard />
   ) : (
     <>
-    {conflictsWithOtherExtensions && <IncompatibleExtensionsOverlay />}
+    {conflictingInfo !== null && (
+      <IncompatibleExtensionsOverlay conflictingInfo={conflictingInfo} />
+    )}
     <LocalStorageProvider>
       <AuthProvider>
         <LayoutTopDiv>


### PR DESCRIPTION
## Description

Since the build script will replac "Continue.continue" to "redhat.granitecode",
here we change the mechanism to grab the extension id during the activation and
remove the current extension id from the incompatible extensions list.
Therefore, we can mitigate two situations that we block ourselves:
  1. The built version (Due to replacing Continue.continue to
     redhat.granitecode)
  2. During dev mode (We are Continue while in dev mode)

We do need to change the build script to skip this file so it can work
properly.

