### PR TITLE
fix: only show the setup wizard on 1st start

### DIFF
--- a/core/granite/commons/constants.ts
+++ b/core/granite/commons/constants.ts
@@ -1,4 +1,9 @@
 export const isDevMode = process.env.CONTINUE_DEVELOPMENT === "true";
 export const isTestMode = process.env.CONTINUE_GLOBAL_DIR?.includes("e2e/test");
 
-export const SHOW_GRANITE_ONBOARDING_CARD_KEY = "showGraniteOnboardingCard";
+//Despite its name, this key is now used to track whether the user has completed the onboarding flow
+// showGraniteOnboardingCard===true means the user has completed the onboarding flow
+export const GRANITE_ONBOARDING_INCOMPLETE_KEY = "showGraniteOnboardingCard";
+
+// This key is used to track whether the user has run the initial activation flow
+export const GRANITE_INITIAL_ACTIVATION_COMPLETED_KEY = "graniteInitialActivationCompleted";

--- a/extensions/vscode/src/granite/panels/setupGranitePage.ts
+++ b/extensions/vscode/src/granite/panels/setupGranitePage.ts
@@ -6,7 +6,7 @@ import {
   DEFAULT_MODEL_GRANITE_SMALL,
 } from "core/config/default";
 import { EXTENSION_NAME } from "core/control-plane/env";
-import { SHOW_GRANITE_ONBOARDING_CARD_KEY } from "core/granite/commons/constants";
+import { GRANITE_ONBOARDING_INCOMPLETE_KEY } from "core/granite/commons/constants";
 import { DOWNLOADABLE_MODELS } from "core/granite/commons/modelRequirements";
 import { ProgressData } from "core/granite/commons/progressData";
 import { ModelStatus, ServerStatus } from "core/granite/commons/statuses";
@@ -84,17 +84,12 @@ export class SetupGranitePage {
           this.wizardState.stepStatuses[MODELS_STEP];
         let reopen = false;
         if (!isComplete) {
-          const RESUME_LABEL = "Resume Setup";
-          const choice = await window.showWarningMessage(
-            "Resume Granite.Code Setup?",
-            {
-              modal: true,
-              detail:
-                "Granite.Code needs to be setup before it can be used. Setup is not yet complete.",
-            },
-            RESUME_LABEL, // Cancel is always shown
+          const REOPEN_LABEL = "Open Setup";
+          const choice = await window.showInformationMessage(
+            "Granite.Code setup is incomplete",
+            REOPEN_LABEL, // Cancel is always shown
           );
-          reopen = choice === RESUME_LABEL;
+          reopen = choice === REOPEN_LABEL;
         }
         this.dispose();
         if (reopen) {
@@ -441,7 +436,7 @@ export class SetupGranitePage {
   }
 
   private async hideGraniteOnboardingCard() {
-    await this.context.globalState.update(SHOW_GRANITE_ONBOARDING_CARD_KEY, false);
+    await this.context.globalState.update(GRANITE_ONBOARDING_INCOMPLETE_KEY, false);
     await commands.executeCommand("setContext", "granite.initialized", true);
     this.chatWebViewProtocol.send("setShowGraniteOnboardingCard", false);
   }

--- a/extensions/vscode/src/granite/utils/extensionUtils.ts
+++ b/extensions/vscode/src/granite/utils/extensionUtils.ts
@@ -1,4 +1,4 @@
-import { isTestMode, SHOW_GRANITE_ONBOARDING_CARD_KEY } from "core/granite/commons/constants";
+import { GRANITE_ONBOARDING_INCOMPLETE_KEY, isTestMode } from "core/granite/commons/constants";
 import { ExtensionContext } from "vscode";
 
 /**
@@ -8,6 +8,6 @@ import { ExtensionContext } from "vscode";
  * @returns True if the Granite onboarding has been completed. Always returns true in test mode.
  */
 export function isGraniteOnboardingComplete(context: ExtensionContext): boolean {
-    const showOnboarding = context.globalState.get<boolean>(SHOW_GRANITE_ONBOARDING_CARD_KEY, true);
-    return (!showOnboarding || isTestMode === true);
+    const isOnboardingIncomplete = context.globalState.get<boolean>(GRANITE_ONBOARDING_INCOMPLETE_KEY, true);
+    return (!isOnboardingIncomplete || isTestMode === true);
 }


### PR DESCRIPTION
## Description

- only show the setup wizard on 1st start
- don't use a modal dialog when closing an incomplete wizard

Fixes https://github.com/Granite-Code/granite-code/issues/118

## Screenshots
When run in dev mode (the running extension id is Continue)

<img width="463" alt="Screenshot 2025-05-14 at 14 04 23" src="https://github.com/user-attachments/assets/d90bad62-4110-4dd9-be39-5ba5092b6ffd" />

## Testing instructions

- close VS Code
- delete the global workspace for the extension you're testing, e.g. on Mac:

> sqlite3 ~/Library/Application\ Support/Code/User/globalStorage/state.vscdb 'delete from ItemTable where key="Continue.continue";'

or 

> sqlite3 ~/Library/Application\ Support/Code/User/globalStorage/state.vscdb 'delete from ItemTable where key="redhat.granitecode";'

- reopen VS Code, the wizard should show up. Restart VS Code, it won't show then.
- try closing the wizard before it's complete, you should see the aforementioned non-modal notification.