### PR TITLE
Improve interaction between Intellisense and Inline Completion

### DIFF
--- a/core/autocomplete/classification/shouldCompleteMultiline.ts
+++ b/core/autocomplete/classification/shouldCompleteMultiline.ts
@@ -23,11 +23,6 @@ export function shouldCompleteMultiline(helper: HelperVars) {
       break;
   }
 
-  // Always single-line if an intellisense option is selected
-  if (helper.input.selectedCompletionInfo) {
-    return true;
-  }
-
   // // Don't complete multi-line if you are mid-line
   // if (isMidlineCompletion(helper.fullPrefix, helper.fullSuffix)) {
   //   return false;

--- a/core/autocomplete/templating/constructPrefixSuffix.ts
+++ b/core/autocomplete/templating/constructPrefixSuffix.ts
@@ -22,8 +22,8 @@ export async function constructInitialPrefixSuffix(
   let prefix =
     getRangeInString(fileContents, {
       start: { line: 0, character: 0 },
-      end: input.selectedCompletionInfo?.range.start ?? input.pos,
-    }) + (input.selectedCompletionInfo?.text ?? "");
+      end: input.pos,
+    });
 
   if (input.injectDetails) {
     const lines = prefix.split("\n");

--- a/core/autocomplete/util/processSingleLineCompletion.ts
+++ b/core/autocomplete/util/processSingleLineCompletion.ts
@@ -41,26 +41,29 @@ function diffPatternMatches(
 type DiffPartType = "+" | "-" | "=";
 
 export function processSingleLineCompletion(
-    lastLineOfCompletionText: string,
+    completionText: string,
     currentText: string,
-    cursorPosition: number
+    cursorPosition: number,
+    mayChangeRange: boolean
 ): SingleLineCompletionResult | undefined {
-    const diffs: DiffType[] = Diff.diffWords(currentText, lastLineOfCompletionText);
+    const diffs: DiffType[] = Diff.diffWords(currentText, completionText);
 
     if (diffPatternMatches(diffs, ["+"])) {
         // Just insert, we're already at the end of the line
         return {
-            completionText: lastLineOfCompletionText,
+            completionText,
         };
     }
 
     if (
-        diffPatternMatches(diffs, ["+", "="]) ||
+        mayChangeRange &&
         diffPatternMatches(diffs, ["+", "=", "+"])
     ) {
-        // The model repeated the text after the cursor to the end of the line
+        // The model inserted something after the cursor and something at the
+        // end of the line; if we can change the range, we can replace the entire
+        // rest of the line.
         return {
-            completionText: lastLineOfCompletionText,
+            completionText,
             range: {
                 start: cursorPosition,
                 end: currentText.length + cursorPosition,
@@ -74,7 +77,7 @@ export function processSingleLineCompletion(
     ) {
         // We are midline and the model just inserted without repeating to the end of the line
         return {
-            completionText: lastLineOfCompletionText,
+            completionText,
         };
     }
 
@@ -87,6 +90,6 @@ export function processSingleLineCompletion(
 
     // Default case: treat as simple insertion
     return {
-        completionText: lastLineOfCompletionText,
+        completionText,
     };
 }

--- a/core/autocomplete/util/types.ts
+++ b/core/autocomplete/util/types.ts
@@ -18,10 +18,6 @@ export interface AutocompleteInput {
   manuallyPassFileContents?: string;
   // Used for VS Code git commit input box
   manuallyPassPrefix?: string;
-  selectedCompletionInfo?: {
-    text: string;
-    range: Range;
-  };
   injectDetails?: string;
 }
 

--- a/extensions/vscode/src/autocomplete/completionProvider.ts
+++ b/extensions/vscode/src/autocomplete/completionProvider.ts
@@ -112,25 +112,6 @@ export class ContinueCompletionProvider
       return null;
     }
 
-    const selectedCompletionInfo = context.selectedCompletionInfo;
-
-    // This code checks if there is a selected completion suggestion in the given context and ensures that it is valid
-    // To improve the accuracy of suggestions it checks if the user has typed at least 4 characters
-    // This helps refine and filter out irrelevant autocomplete options
-    if (selectedCompletionInfo) {
-      const { text, range } = selectedCompletionInfo;
-      const typedText = document.getText(range);
-
-      const typedLength = range.end.character - range.start.character;
-
-      if (typedLength < 4) {
-        return null;
-      }
-
-      if (!text.startsWith(typedText)) {
-        return null;
-      }
-    }
     let injectDetails: string | undefined = undefined;
 
     try {

--- a/extensions/vscode/src/autocomplete/completionProvider.ts
+++ b/extensions/vscode/src/autocomplete/completionProvider.ts
@@ -191,6 +191,21 @@ export class ContinueCompletionProvider
 
       const selectedCompletionInfo = context.selectedCompletionInfo;
 
+      // Special case that helps completion with the Granite models:
+      //
+      // If the displayed completion in the autocompletion widget is a property,
+      // and the result from Granite starts with spaces before the property dot,
+      // remove those spaces.
+      if (
+        selectedCompletionInfo &&
+        selectedCompletionInfo.text.startsWith(".")
+      ) {
+        const trimmedCompletion = outcome.completion.trimStart();
+        if (trimmedCompletion.startsWith(".")) {
+          outcome.completion = trimmedCompletion;
+        }
+      }
+
       // Construct the range/text to show
       let range = new vscode.Range(position, position);
       let completionText = outcome.completion;

--- a/extensions/vscode/src/autocomplete/completionProvider.ts
+++ b/extensions/vscode/src/autocomplete/completionProvider.ts
@@ -31,7 +31,8 @@ interface VsCodeCompletionInput {
 }
 
 export class ContinueCompletionProvider
-  implements vscode.InlineCompletionItemProvider {
+  implements vscode.InlineCompletionItemProvider
+{
   private async onError(e: any) {
     if (await handleLLMError(e)) {
       return;
@@ -87,7 +88,6 @@ export class ContinueCompletionProvider
   }
 
   _lastShownCompletion: AutocompleteOutcome | undefined;
-
 
   public async provideInlineCompletionItems(
     document: vscode.TextDocument,

--- a/extensions/vscode/src/autocomplete/completionProvider.ts
+++ b/extensions/vscode/src/autocomplete/completionProvider.ts
@@ -169,7 +169,6 @@ export class ContinueCompletionProvider
         pos,
         manuallyPassFileContents,
         manuallyPassPrefix,
-        selectedCompletionInfo,
         injectDetails,
         isUntitledFile: document.isUntitled,
         completionId: uuidv4(),


### PR DESCRIPTION
This patchset is intended to be a fairly simple and reliable set of patches to improve the way intellisense and autocompletion interact. It's based on work by @panyamkeerthana and @halfline See https://github.com/continuedev/continue/pull/5543 for the bulk of @halfline's work - that does a lot more, but there are also some issues cropping up so this hopefully will be a robust way improve things in the short term.

Summary of changes here:
 - Stop adding the selected completion to the model input - the inline autocompletion should be in charge when available, not vice-versa. 
 - Make sure the returned ranges match what vscode expects - if intellisense is returning a range of `[.]` when completing `foo.` then we should do the same and return `[.]bar` not `[]bar`
 - Handle the case where the model completes foo with ` .bar` (a leading space) and that doesn't match an intellisense option by stripping the space.
 - Adjust the way we handling trailing line contents when the completion widget is shown - don't try to do fancy range completion where we replace the existing line end since that causes our completions to be ignored..