### PR TITLE
feat: don't offer the small model from the wizard

### DIFF
--- a/extensions/vscode/src/granite/panels/setupGranitePage.ts
+++ b/extensions/vscode/src/granite/panels/setupGranitePage.ts
@@ -1,6 +1,7 @@
 import { LocalModelSize } from "core";
 import { ConfigHandler } from "core/config/ConfigHandler";
 import {
+  DEFAULT_GRANITE_EMBEDDING_MODEL,
   DEFAULT_MODEL_GRANITE_LARGE,
   DEFAULT_MODEL_GRANITE_SMALL,
 } from "core/config/default";
@@ -487,6 +488,12 @@ export class SetupGranitePage {
     this.wizardState.stepStatuses[OLLAMA_STEP] = serverVersion !== undefined && checkMinimumServerVersion(serverVersion) && (
       serverState.status === ServerStatus.started ||
       serverState.status === ServerStatus.stopped);
+
+    const allModelsInstalled = statusByModel.get(DEFAULT_MODEL_GRANITE_LARGE.model) === ModelStatus.installed
+      && statusByModel.get(DEFAULT_GRANITE_EMBEDDING_MODEL.model) === ModelStatus.installed;
+
+    this.wizardState.stepStatuses[MODELS_STEP] = allModelsInstalled;
+
     await webview.postMessage({
       command: "status",
       data: {


### PR DESCRIPTION
## Description

Remove the small model selection in the Granite Wizard.

For now, we're still setting the "large" model under the hood. But we might need to come up with a different approach, as keeping the `continue.localModelSize` setting make no sense to a user.

When the models (granite + embedder) are already installed and up to date, we skip the model download section. 

PS: In a 1st separate commit, I fixed all warnings about promises needing to be awaited

Fixes https://github.com/Granite-Code/granite-code/issues/117
## Screenshots

<img width="631" alt="Screenshot 2025-05-22 at 13 38 45" src="https://github.com/user-attachments/assets/f940bd9e-93ba-4917-b9d8-ac9451861528" />


## Testing instructions

Run the `Granite.Code: Setup Granite as AI assistant` command to open the wizard