### PR TITLE
fix: hide autocomplete model toggle when only 1 model available

### DIFF
--- a/extensions/vscode/src/commands.ts
+++ b/extensions/vscode/src/commands.ts
@@ -660,7 +660,7 @@ const getCommandsMap: (
             : StatusBarStatus.Disabled;
       }
 
-      quickPick.items = [
+      const baseItems = [
         {
           label: "$(gear) Open settings",
         },
@@ -683,6 +683,10 @@ const getCommandsMap: (
           label: "$(feedback) Give feedback",
         },
         */
+      ];
+
+      quickPick.items = autocompleteModels.length > 1 ? [
+        ...baseItems,
         {
           kind: vscode.QuickPickItemKind.Separator,
           label: "Switch model",
@@ -690,8 +694,8 @@ const getCommandsMap: (
         ...autocompleteModels.map((model) => ({
           label: getAutocompleteStatusBarTitle(selected, model),
           description: getAutocompleteStatusBarDescription(selected, model),
-        })),
-      ];
+        }))
+      ] : baseItems;
       quickPick.onDidAccept(() => {
         const selectedOption = quickPick.selectedItems[0].label;
         const targetStatus =


### PR DESCRIPTION
## Description

Hide the autocomplete model switch label, when there's only one autocomplete model to choose from

Fixes https://github.com/Granite-Code/granite-code/issues/122

## Screenshots

1 model available:
<img width="607" alt="Screenshot 2025-05-27 at 16 25 40" src="https://github.com/user-attachments/assets/9c00a846-a51b-430c-ad77-dc169f36cd1c" />


multiple models available (see https://github.com/Granite-Code/granite-code/issues/124):

<img width="608" alt="Screenshot 2025-05-27 at 16 32 47" src="https://github.com/user-attachments/assets/1c0bdb58-eb31-43bd-b14f-a65411fc1529" />
