### PR TITLE
Fix $HOME/.continue references and isolate logins

### DIFF
--- a/core/config/load.ts
+++ b/core/config/load.ts
@@ -798,7 +798,7 @@ async function tryBuildConfigTs() {
     }
   } catch (e) {
     console.log(
-      `Build error. Please check your ~/.continue/config.ts file: ${e}`,
+      `Build error. Please check your ~/.granite-code/config.ts file: ${e}`,
     );
   }
 }
@@ -982,5 +982,6 @@ export {
   intermediateToFinalConfig,
   loadContinueConfigFromJson,
   writeContinueConfig,
-  type BrowserSerializedContinueConfig,
+  type BrowserSerializedContinueConfig
 };
+

--- a/core/config/loadLocalAssistants.ts
+++ b/core/config/loadLocalAssistants.ts
@@ -10,7 +10,7 @@ import { localPathToUri } from "../util/pathToUri";
 import { joinPathsToUri } from "../util/uri";
 
 export const ASSISTANTS = "assistants";
-export const ASSISTANTS_FOLDER = `.continue/${ASSISTANTS}`;
+export const ASSISTANTS_FOLDER = `.granite-code/${ASSISTANTS}`;
 
 export function isLocalAssistantFile(uri: string): boolean {
   if (!uri.endsWith(".yaml") && !uri.endsWith(".yml")) {
@@ -67,14 +67,14 @@ export function getDotContinueSubDirs(
 ): string[] {
   let fullDirs: string[] = [];
 
-  // Workspace .continue/<subDirName>
+  // Workspace .granite-code/<subDirName>
   if (options.includeWorkspace) {
     fullDirs = workspaceDirs.map((dir) =>
-      joinPathsToUri(dir, ".continue", subDirName),
+      joinPathsToUri(dir, ".granite-code", subDirName),
     );
   }
 
-  // ~/.continue/<subDirName>
+  // ~/.granite-code/<subDirName>
   if (options.includeGlobal) {
     fullDirs.push(localPathToUri(getGlobalFolderWithName(subDirName)));
   }
@@ -83,8 +83,8 @@ export function getDotContinueSubDirs(
 }
 
 /**
- * This method searches in both ~/.continue and workspace .continue
- * for all YAML files in the specified subdirctory, for example .continue/assistants or .continue/prompts
+ * This method searches in both ~/.granite-code and workspace .granite-code
+ * for all YAML files in the specified subdirctory, for example .granite-code/assistants or .granite-code/prompts
  */
 export async function getAllDotContinueYamlFiles(
   ide: IDE,

--- a/core/config/yaml/LocalPlatformClient.ts
+++ b/core/config/yaml/LocalPlatformClient.ts
@@ -44,7 +44,7 @@ export class LocalPlatformClient implements PlatformClient {
       return dotEnv[fqsn.secretName];
     } catch (error) {
       console.warn(
-        `Error reading ~/.continue/.env file: ${error instanceof Error ? error.message : String(error)}`,
+        `Error reading ~/.granite-code/.env file: ${error instanceof Error ? error.message : String(error)}`,
       );
       return undefined;
     }

--- a/core/core.ts
+++ b/core/core.ts
@@ -843,7 +843,7 @@ export class Core {
           uri.endsWith(".continuerc.json") ||
           uri.endsWith(".prompt") ||
           uri.endsWith(SYSTEM_PROMPT_DOT_FILE) ||
-          (uri.includes(".continue") && uri.endsWith(".yaml"))
+          (uri.includes(".granite-code") && uri.endsWith(".yaml"))
         ) {
           await this.configHandler.reloadConfig();
         } else if (

--- a/core/indexing/ignore.ts
+++ b/core/indexing/ignore.ts
@@ -100,6 +100,7 @@ export const DEFAULT_IGNORE_DIRS = [
   ".pytest_cache/",
   ".vscode-test/",
   ".continue/",
+  ".granite-code/",
   "__pycache__/",
   "site-packages/",
   ".gradle/",

--- a/core/promptFiles/v2/createNewPromptFile.ts
+++ b/core/promptFiles/v2/createNewPromptFile.ts
@@ -48,7 +48,7 @@ export async function createNewPromptFileV2(
 
   const baseDirUri = joinPathsToUri(
     workspaceDirs[0],
-    promptPath ?? ".continue/prompts",
+    promptPath ?? ".granite-code/prompts",
   );
 
   // Find the first available filename

--- a/core/promptFiles/v2/getPromptFiles.ts
+++ b/core/promptFiles/v2/getPromptFiles.ts
@@ -4,7 +4,7 @@ import { readAllGlobalPromptFiles } from "../../util/paths";
 import { joinPathsToUri } from "../../util/uri";
 import { DEFAULT_PROMPTS_FOLDER_V1 } from "../v1";
 
-export const DEFAULT_PROMPTS_FOLDER_V2 = ".continue/prompts";
+export const DEFAULT_PROMPTS_FOLDER_V2 = ".granite-code/prompts";
 export async function getPromptFilesFromDir(
   ide: IDE,
   dir: string,
@@ -55,7 +55,7 @@ export async function getAllPromptFiles(
     await Promise.all(fullDirs.map((dir) => getPromptFilesFromDir(ide, dir)))
   ).flat();
 
-  // Also read from ~/.continue/.prompts
+  // Also read from ~/.granite-code/.prompts
   promptFiles.push(...readAllGlobalPromptFiles());
 
   return await Promise.all(

--- a/core/tools/implementations/createRuleBlock.ts
+++ b/core/tools/implementations/createRuleBlock.ts
@@ -37,7 +37,7 @@ export const createRuleBlockImpl: ToolImpl = async (
   const [localContinueDir] = await extras.ide.getWorkspaceDirs();
   const rulesDirUri = joinPathsToUri(
     localContinueDir,
-    ".continue",
+    ".granite-code",
     "rules",
     `${safeRuleName}.yaml`,
   );

--- a/extensions/vscode/src/lang-server/codeLens/providers/ConfigJsonConverterCodeLensProvider.ts
+++ b/extensions/vscode/src/lang-server/codeLens/providers/ConfigJsonConverterCodeLensProvider.ts
@@ -10,7 +10,7 @@ export class ConfigJsonConverterCodeLensProvider
     _: vscode.CancellationToken,
   ): vscode.CodeLens[] | Thenable<vscode.CodeLens[]> {
     if (
-      !document.uri.fsPath.includes(".continue") ||
+      !document.uri.fsPath.includes(".granite-code") ||
       !document.uri.fsPath.endsWith("config.json")
     ) {
       return [];

--- a/extensions/vscode/src/lang-server/codeLens/providers/DownloadYamlExtensionCodeLensProvider.ts
+++ b/extensions/vscode/src/lang-server/codeLens/providers/DownloadYamlExtensionCodeLensProvider.ts
@@ -12,7 +12,7 @@ export class DownloadYamlExtensionCodeLensProvider
     document: vscode.TextDocument,
     _: vscode.CancellationToken,
   ): vscode.CodeLens[] | Thenable<vscode.CodeLens[]> {
-    if (!document.uri.fsPath.includes(".continue")) {
+    if (!document.uri.fsPath.includes(".granite-code")) {
       return [];
     }
     if (this.yamlExtensionDownloaded()) {

--- a/extensions/vscode/src/lang-server/codeLens/registerAllCodeLensProviders.ts
+++ b/extensions/vscode/src/lang-server/codeLens/registerAllCodeLensProviders.ts
@@ -122,11 +122,6 @@ export function registerAllCodeLensProviders(
     new providers.SuggestionsCodeLensProvider(),
   );
 
-  configJsonConverterCodeLensDisposable = registerCodeLensProvider(
-    "*",
-    new providers.ConfigJsonConverterCodeLensProvider(),
-  );
-
   downloadYamlExtensionCodeLensDisposable = registerCodeLensProvider(
     "yaml",
     new providers.DownloadYamlExtensionCodeLensProvider(),
@@ -142,7 +137,6 @@ export function registerAllCodeLensProviders(
 
   context.subscriptions.push(verticalPerLineCodeLensProvider);
   context.subscriptions.push(suggestionsCodeLensDisposable);
-  context.subscriptions.push(configJsonConverterCodeLensDisposable);
 
   return { verticalDiffCodeLens };
 }

--- a/extensions/vscode/src/stubs/WorkOsAuthProvider.ts
+++ b/extensions/vscode/src/stubs/WorkOsAuthProvider.ts
@@ -22,7 +22,7 @@ import { PromiseAdapter, promiseFromEvent } from "./promiseUtils";
 import { SecretStorage } from "./SecretStorage";
 import { UriEventHandler } from "./uriHandler";
 
-const AUTH_NAME = "Continue";
+const AUTH_NAME = "Granite.Code";
 
 const controlPlaneEnv = getControlPlaneEnvSync(true ? "production" : "none");
 

--- a/gui/src/components/History/index.tsx
+++ b/gui/src/components/History/index.tsx
@@ -203,7 +203,7 @@ export function History() {
         <i
           className=""
           data-testid="history-sessions-note"
-        >{`Data is saved in ${platform === "windows" ? "%USERPROFILE%/.continue" : "~/.continue/sessions"}`}</i>
+        >{`Data is saved in ${platform === "windows" ? "%USERPROFILE%/.granite-code" : "~/.granite-code/sessions"}`}</i>
         <span
           className="cursor-pointer text-xs text-gray-400 hover:underline"
           onClick={showClearSessionsDialog}


### PR DESCRIPTION
This PR fixes a few leftover references to $HOME/.continue and <workspace>/.continue, and also changes the authentication name, which will hopefully keep us from carrying "logged into hub.continue.dev" into a devel session on the granite/customization branch.

Fixes Granite-Code/granite-code#124
