### PR TITLE
fix: properly set the wizard as complete when all requirements are met

### DIFF
--- a/core/protocol/ideWebview.ts
+++ b/core/protocol/ideWebview.ts
@@ -56,7 +56,7 @@ export type ToIdeFromWebviewProtocol = ToIdeFromWebviewOrCoreProtocol & {
   ];
   "edit/addCurrentSelection": [undefined, void];
   "edit/clearDecorations": [undefined, void];
-  checkForIncompatibleExtensions: [undefined, void];
+  onWebviewLoad: [undefined, void];
 };
 
 export type ToWebviewFromIdeProtocol = ToWebviewFromIdeOrCoreProtocol & {

--- a/extensions/vscode/src/VsCodeIde.ts
+++ b/extensions/vscode/src/VsCodeIde.ts
@@ -9,6 +9,7 @@ import * as URI from "uri-js";
 import * as vscode from "vscode";
 
 import { executeGotoProvider } from "./autocomplete/lsp";
+import { isGraniteOnboardingComplete } from "./granite/utils/extensionUtils";
 import { Repository } from "./otherExtensions/git";
 import { SecretStorage } from "./stubs/SecretStorage";
 import { VsCodeIdeUtils } from "./util/ideUtils";
@@ -788,6 +789,10 @@ class VsCodeIde implements IDE {
   async getIdeSettings(): Promise<IdeSettings> {
     const ideSettings = this.getIdeSettingsSync();
     return ideSettings;
+  }
+
+  isGraniteOnboardingComplete(): boolean {
+    return isGraniteOnboardingComplete(this.context);
   }
 }
 

--- a/extensions/vscode/src/extension/VsCodeMessenger.ts
+++ b/extensions/vscode/src/extension/VsCodeMessenger.ts
@@ -250,7 +250,9 @@ export class VsCodeMessenger {
     this.onWebview("edit/clearDecorations", async (msg) => {
       editDecorationManager.clear();
     });
-    this.onWebview("checkForIncompatibleExtensions", async (msg) => {
+    this.onWebview("onWebviewLoad", async (msg) => {
+      const isGraniteOnboardingComplete = ide.isGraniteOnboardingComplete();
+      this.webviewProtocol.send("setShowGraniteOnboardingCard", !isGraniteOnboardingComplete);
       this.webviewProtocol.send("updateIncompatibleExtensions", checkForIncompatibleExtensions());
     });
 

--- a/extensions/vscode/src/granite/panels/setupGranitePage.ts
+++ b/extensions/vscode/src/granite/panels/setupGranitePage.ts
@@ -409,12 +409,9 @@ export class SetupGranitePage {
         this.modelInstallCanceller.signal,
         reportProgress,
       );
-      this.wizardState.stepStatuses[MODELS_STEP] = result;
       await this.publishStatus(webview);
       if (result) {
         await this.saveSettings(modelSize);
-        await this.hideGraniteOnboardingCard();
-        await commands.executeCommand("continue.continueGUIView.focus");
         if (!panel.visible) {
           const selection = await window.showInformationMessage(
             "Granite.Code is ready to be used.",
@@ -488,11 +485,16 @@ export class SetupGranitePage {
       serverState.status === ServerStatus.started ||
       serverState.status === ServerStatus.stopped);
 
+    const prevModelStatus = this.wizardState.stepStatuses[MODELS_STEP];
     const allModelsInstalled = modelIds.every(
       (id) => statusByModel.get(id) === ModelStatus.installed,
     );
 
     this.wizardState.stepStatuses[MODELS_STEP] = allModelsInstalled;
+    if (allModelsInstalled && !prevModelStatus) {
+      await commands.executeCommand("continue.continueGUIView.focus");
+      await this.hideGraniteOnboardingCard();
+    }
 
     await webview.postMessage({
       command: "status",

--- a/gui/src/components/Layout.tsx
+++ b/gui/src/components/Layout.tsx
@@ -196,9 +196,9 @@ const Layout = () => {
     };
   }, []);
 
-  // Check if there are any incompatible extension enabled when the webview is on mount
+  // When the webview is on mount, check if there are any incompatible extension enabled, and if the onboardingCard should be shown
   useEffect(() => {
-    ideMessenger.post("checkForIncompatibleExtensions", undefined);
+    ideMessenger.post("onWebviewLoad", undefined);
   }, []);
 
   return showGraniteOnboardingCard ? (


### PR DESCRIPTION
When all models are already installed and you install Granite.Code for the 1st time, the models don't need to be downloaded so we don't toggle the onboarding status, meaning the chat view always shows the Granite onboarding card, chat is disabled.