### PR TITLE
Feat: include .graniteignore and .graniterules for Granite.Code

### DIFF
--- a/core/commands/slash/onboard.ts
+++ b/core/commands/slash/onboard.ts
@@ -1,11 +1,8 @@
 import ignore from "ignore";
 
 import type { FileType, IDE, SlashCommand } from "../..";
-import {
-  DEFAULT_IGNORE,
-  getGlobalContinueIgArray,
-  gitIgArrayFromFile,
-} from "../../indexing/ignore";
+import { getGlobalIgnoreArray } from "../../granite/config/graniteDotFiles";
+import { DEFAULT_IGNORE, gitIgArrayFromFile } from "../../indexing/ignore";
 import { renderChatMessage } from "../../util/messageContent";
 import {
   findUriInDirs,
@@ -57,7 +54,8 @@ const OnboardSlashCommand: SlashCommand = {
 };
 
 async function getEntriesFilteredByIgnore(dir: string, ide: IDE) {
-  const ig = ignore().add(DEFAULT_IGNORE).add(getGlobalContinueIgArray());
+  const ignoreArray = await getGlobalIgnoreArray(ide);
+  const ig = ignore().add(DEFAULT_IGNORE).add(ignoreArray);
   const entries = await ide.listDir(dir);
 
   const ignoreUri = joinPathsToUri(dir, ".gitignore");

--- a/core/config/getWorkspaceContinueRuleDotFiles.ts
+++ b/core/config/getWorkspaceContinueRuleDotFiles.ts
@@ -1,5 +1,7 @@
 import { ConfigValidationError } from "@continuedev/config-yaml";
+import type { RuleSource } from "..";
 import { IDE, RuleWithSource } from "..";
+import { getRulesDotFile } from "../granite/config/graniteDotFiles";
 import { joinPathsToUri } from "../util/uri";
 export const SYSTEM_PROMPT_DOT_FILE = ".continuerules";
 
@@ -10,14 +12,15 @@ export async function getWorkspaceContinueRuleDotFiles(ide: IDE) {
   const rules: RuleWithSource[] = [];
   for (const dir of dirs) {
     try {
-      const dotFile = joinPathsToUri(dir, SYSTEM_PROMPT_DOT_FILE);
+      const rulesFileName = await getRulesDotFile(ide, dir);
+      const dotFile = joinPathsToUri(dir, rulesFileName);
       const exists = await ide.fileExists(dotFile);
       if (exists) {
         const content = await ide.readFile(dotFile);
         rules.push({
           rule: content,
           ruleFile: dotFile,
-          source: ".continuerules",
+          source: rulesFileName as RuleSource,
         });
       }
     } catch (e) {

--- a/core/granite/config/graniteDotFiles.ts
+++ b/core/granite/config/graniteDotFiles.ts
@@ -1,0 +1,89 @@
+import fs from "fs";
+import { pathToFileURL } from "node:url";
+import { IDE } from "../..";
+import { SYSTEM_PROMPT_DOT_FILE } from "../../config/getWorkspaceContinueRuleDotFiles";
+import {
+  getGlobalContinueIgArray,
+  gitIgArrayFromFile,
+} from "../../indexing/ignore";
+import { getGlobalGraniteIgnorePath } from "../../util/paths";
+import { joinPathsToUri } from "../../util/uri";
+export const GRANITE_SYSTEM_PROMPT_DOT_FILE = ".graniterules";
+export const GRANITE_IGNORE_DOT_FILE = ".graniteignore";
+
+type DotFilesMode = "granite" | "continue";
+
+async function checkCurrentDirDotFileMode(
+  ide: IDE,
+  dotFileName: string,
+  curDir: string,
+): Promise<DotFilesMode> {
+  const dotFilePath = joinPathsToUri(curDir, dotFileName);
+  const exists = await ide.fileExists(dotFilePath);
+  if (exists) {
+    return "granite";
+  }
+  return "continue";
+}
+
+async function checkGlobalIgnoreFileMode(ide: IDE): Promise<DotFilesMode> {
+  const graniteGlobalIgnoreFilePath = getGlobalGraniteIgnorePath();
+  const fileUrl = pathToFileURL(graniteGlobalIgnoreFilePath).href;
+
+  if (await ide.fileExists(fileUrl)) {
+    return "granite";
+  }
+
+  return "continue";
+}
+
+async function checkRulesDotFilesMode(
+  ide: IDE,
+  curDir: string,
+): Promise<DotFilesMode> {
+  return checkCurrentDirDotFileMode(
+    ide,
+    GRANITE_SYSTEM_PROMPT_DOT_FILE,
+    curDir,
+  );
+}
+
+async function checkIgnoreDotFilesMode(
+  ide: IDE,
+  curDir: string,
+): Promise<DotFilesMode> {
+  return checkCurrentDirDotFileMode(ide, GRANITE_IGNORE_DOT_FILE, curDir);
+}
+
+export async function getIgnoreDotFile(
+  ide: IDE,
+  curDir: string,
+): Promise<string> {
+  return (await checkIgnoreDotFilesMode(ide, curDir)) === "granite"
+    ? GRANITE_IGNORE_DOT_FILE
+    : ".continueignore";
+}
+
+export async function getRulesDotFile(
+  ide: IDE,
+  curDir: string,
+): Promise<string> {
+  return (await checkRulesDotFilesMode(ide, curDir)) === "granite"
+    ? GRANITE_SYSTEM_PROMPT_DOT_FILE
+    : SYSTEM_PROMPT_DOT_FILE;
+}
+
+export async function getGlobalIgnoreArray(ide: IDE): Promise<string[]> {
+  return (await checkGlobalIgnoreFileMode(ide)) === "granite"
+    ? getGlobalGraniteIgArray()
+    : getGlobalContinueIgArray();
+}
+
+const getGlobalGraniteIgArray = () => {
+  try {
+    const contents = fs.readFileSync(getGlobalGraniteIgnorePath(), "utf8");
+    return gitIgArrayFromFile(contents);
+  } catch (e) {
+    return [];
+  }
+};

--- a/core/index.d.ts
+++ b/core/index.d.ts
@@ -1565,6 +1565,7 @@ export type RuleSource =
   | "model-agent-options"
   | "rules-block"
   | "json-systemMessage"
+  | ".graniterules"
   | ".continuerules";
 
 export interface RuleWithSource {

--- a/core/indexing/ignore.ts
+++ b/core/indexing/ignore.ts
@@ -67,6 +67,8 @@ export const DEFAULT_IGNORE_FILETYPES = [
   "*.gitignore",
   "*.gitkeep",
   "*.continueignore",
+  "*.graniteignore",
+  "*.graniterules",
   "config.json",
   "config.yaml",
   "*.csv",

--- a/core/indexing/shouldIgnore.ts
+++ b/core/indexing/shouldIgnore.ts
@@ -1,7 +1,8 @@
 import ignore from "ignore";
 import type { FileType, IDE } from "../";
+import { getGlobalIgnoreArray } from "../granite/config/graniteDotFiles";
 import { findUriInDirs, getUriPathBasename } from "../util/uri";
-import { defaultIgnoreFileAndDir, getGlobalContinueIgArray } from "./ignore";
+import { defaultIgnoreFileAndDir } from "./ignore";
 import { getIgnoreContext } from "./walkDir";
 
 /*
@@ -23,9 +24,11 @@ export async function shouldIgnore(
     return true;
   }
 
+  const ignoreArray = await getGlobalIgnoreArray(ide);
+
   const defaultAndGlobalIgnores = ignore()
     .add(defaultIgnoreFileAndDir)
-    .add(getGlobalContinueIgArray());
+    .add(ignoreArray);
 
   let currentDir = uri;
   let directParent = true;

--- a/core/indexing/walkDir.test.ts
+++ b/core/indexing/walkDir.test.ts
@@ -381,5 +381,53 @@ describe("walkDir functions", () => {
       expect(files).not.toContain("xyz/xyz");
       expect(files).toContain("xyz/normal.txt");
     });
+
+    it("should handle both gitignore and graniteignore", async () => {
+      addToTestDir([
+        [".gitignore", "*.py"],
+        [".graniteignore", "*.ts"],
+        ["a.txt", "content"],
+        ["b.py", "content"],
+        ["c.ts", "content"],
+        ["d.js", "content"],
+      ]);
+
+      const files = await walkDir(
+        (await testIde.getWorkspaceDirs())[0],
+        testIde,
+        {
+          returnRelativeUrisPaths: true,
+        },
+      );
+
+      expect(files).toContain("a.txt");
+      expect(files).toContain("d.js");
+      expect(files).not.toContain("b.py");
+      expect(files).not.toContain("c.ts");
+    });
+
+    it("should bypass the content of continueignore when graniteignore exists", async () => {
+      addToTestDir([
+        [".continueignore", "*.py"],
+        [".graniteignore", "*.ts"],
+        ["a.txt", "content"],
+        ["b.py", "content"],
+        ["c.ts", "content"],
+        ["d.js", "content"],
+      ]);
+
+      const files = await walkDir(
+        (await testIde.getWorkspaceDirs())[0],
+        testIde,
+        {
+          returnRelativeUrisPaths: true,
+        },
+      );
+
+      expect(files).toContain("a.txt");
+      expect(files).toContain("d.js");
+      expect(files).toContain("b.py");
+      expect(files).not.toContain("c.ts");
+    });
   });
 });

--- a/core/util/paths.ts
+++ b/core/util/paths.ts
@@ -10,6 +10,7 @@ import dotenv from "dotenv";
 import { IdeType, SerializedContinueConfig } from "../";
 import { defaultConfig, defaultConfigJetBrains } from "../config/default";
 import Types from "../config/types";
+import { GRANITE_IGNORE_DOT_FILE } from "../granite/config/graniteDotFiles";
 
 dotenv.config();
 
@@ -53,6 +54,14 @@ export function getGlobalContinueIgnorePath(): string {
     fs.writeFileSync(continueIgnorePath, "");
   }
   return continueIgnorePath;
+}
+
+export function getGlobalGraniteIgnorePath(): string {
+  const graniteIgnorePath = path.join(
+    getContinueGlobalPath(),
+    GRANITE_IGNORE_DOT_FILE,
+  );
+  return graniteIgnorePath;
 }
 
 export function getContinueGlobalPath(): string {

--- a/core/util/uri.ts
+++ b/core/util/uri.ts
@@ -31,6 +31,7 @@ export function findUriInDirs(
   foundInDir: string | null;
 } {
   const uriComps = URI.parse(uri);
+
   if (!uriComps.scheme) {
     throw new Error(`Invalid uri: ${uri}`);
   }
@@ -196,4 +197,10 @@ export function getUriDescription(uri: string, dirUriCandidates: string[]) {
     last2Parts,
     baseName,
   };
+}
+
+export function getDirectParentDir(filePath: string): string {
+  const parts = filePath.split("/");
+  parts.pop();
+  return parts.join("/");
 }


### PR DESCRIPTION
## Description

This feature add the functionality for Granite.Code to check `.graniteignore` files for ignore files, and `.graniterules` files for customized system prompts (note: `.continuerules` will be deprecated in a future release of Continue).

Note: The ignore files affects what files will be excluded for indexing codebase. They also affect
some file searching functions.

Here is the detail for this new mechanism:
	
1. For `.graniteignore` files, if it exists at current folder, it will be the only ignore
           file we account for. The `.continueignore` file at the same directory will be ignored.
2. The above rule is also applied to .graniterules. The only difference is `.continuerules` and
           `.graniterules` will only be detected at the workspace directory.

I also added test cases for the `shouldIgnore` and `walkDir` functions to ensure they behave as expected and correctly handle file exclusion based on ignore rules in `.graniteignore`.

I put a "test search workspace!" button at the bottom right corner to trigger the search files function and send the result to the modal dialog so this feature can be easily tested. I'll remove this button when we're ready to merge.

https://github.com/Granite-Code/granite-code/issues/129

## Checklist

- [x] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [ ] The relevant docs, if any, have been updated or created
- [x] The relevant tests, if any, have been updated or created

## Tests

  Add `.graniteignore` at any directories under workspace directory, and check if the exclusion of `.continueignore` loses effects. `.graniteignore` should have the same exclusion effect as `.continueignore`.