### PR TITLE
fix: use proper configuration to check for Granite model updates

### DIFF
--- a/extensions/vscode/src/activation/activate.ts
+++ b/extensions/vscode/src/activation/activate.ts
@@ -89,7 +89,7 @@ export async function activateExtension(context: vscode.ExtensionContext) {
     );
   }
 
-  registerModelUpdater(context);
+  await registerModelUpdater(context);
 
   const continuePublicApi = {
     registerCustomContextProvider: api.registerCustomContextProvider.bind(api),

--- a/extensions/vscode/src/granite/ollama/modelUpdater.ts
+++ b/extensions/vscode/src/granite/ollama/modelUpdater.ts
@@ -64,10 +64,10 @@ export class ModelUpdater implements Disposable {
 
   private async checkModelUpdates(): Promise<void> {
     try {
-      console.log("Checking for model updates...");
       const type = workspace
         .getConfiguration(EXTENSION_NAME)
-        .get<LocalModelSize>("modelSize");
+        .get<LocalModelSize>("localModelSize", "large");
+      console.log(`Checking for [${type}] model updates...`);
       const modelsToCheck =
         type === "large"
           ? DEFAULT_GRANITE_MODEL_IDS_LARGE
@@ -157,7 +157,7 @@ export class ModelUpdater implements Disposable {
         } catch (error) {
           if (!abortController.signal.aborted) {
             console.error("Failed to update models:", error);
-            window.showErrorMessage(
+            await window.showErrorMessage(
               "Failed to update models. Please try again later.",
             );
           }


### PR DESCRIPTION
The ModelUpdater was looking for the "modelSize" config key, instead of "localModelSize". Since the result was `undefined`, it would then look for `small` granite model updates, instead of `large`.

Fixes https://github.com/Granite-Code/granite-code/issues/141

 
