### PR TITLE
feat: unload Ollama models on shutdown

### DIFF
--- a/extensions/vscode/src/activation/activate.ts
+++ b/extensions/vscode/src/activation/activate.ts
@@ -1,17 +1,25 @@
 import * as path from "path";
 
+import { LocalModelSize } from "core";
+import {
+  DEFAULT_GRANITE_MODEL_IDS_LARGE,
+  DEFAULT_GRANITE_MODEL_IDS_SMALL,
+} from "core/config/default";
+import { EXTENSION_NAME } from "core/control-plane/env";
+import { GRANITE_INITIAL_ACTIVATION_COMPLETED_KEY } from "core/granite/commons/constants";
 import { getContinueRcPath, getTsConfigPath } from "core/util/paths";
 import { Telemetry } from "core/util/posthog";
 import * as vscode from "vscode";
+import { workspace } from "vscode";
 
 import { VsCodeExtension } from "../extension/VsCodeExtension";
 import { registerModelUpdater } from "../granite/ollama/modelUpdater";
+import { OllamaServer } from "../granite/ollama/ollamaServer";
 import { replaceCopilotWithGraniteCode } from "../granite/utils/compatibilityUtils";
 import { isGraniteOnboardingComplete } from "../granite/utils/extensionUtils";
 import registerQuickFixProvider from "../lang-server/codeActions";
 import { getExtensionVersion } from "../util/util";
 
-import { GRANITE_INITIAL_ACTIVATION_COMPLETED_KEY } from "core/granite/commons/constants";
 import { VsCodeContinueApi } from "./api";
 import setupInlineTips from "./InlineTipManager";
 
@@ -103,4 +111,29 @@ export async function activateExtension(context: vscode.ExtensionContext) {
         extension: vscodeExtension,
       }
     : continuePublicApi;
+}
+
+export async function deactivate(context: vscode.ExtensionContext) {
+  // Unload Granite LLMs from Ollama
+  const type = workspace
+    .getConfiguration(EXTENSION_NAME)
+    .get<LocalModelSize>("localModelSize");
+  const modelsToUnload =
+    type === "large"
+      ? DEFAULT_GRANITE_MODEL_IDS_LARGE
+      : DEFAULT_GRANITE_MODEL_IDS_SMALL;
+
+  const ollamaServer = new OllamaServer(context);
+  let unloadedModels = 0;
+  await Promise.all(
+    modelsToUnload.map(async (model) => {
+      try {
+        await ollamaServer.unloadModel(model);
+        unloadedModels++;
+      } catch (error: any) {
+        console.error(error?.message ?? error);
+      }
+    }),
+  );
+  console.log(`Unloaded ${unloadedModels} models`);
 }

--- a/extensions/vscode/src/extension.ts
+++ b/extensions/vscode/src/extension.ts
@@ -10,6 +10,8 @@ import * as vscode from "vscode";
 import { getExtensionVersion } from "./util/util";
 export { default as buildTimestamp } from "./.buildTimestamp";
 
+let ctx: vscode.ExtensionContext | undefined;
+
 async function dynamicImportAndActivate(context: vscode.ExtensionContext) {
   await setupCa();
   const { activateExtension } = await import("./activation/activate");
@@ -17,6 +19,7 @@ async function dynamicImportAndActivate(context: vscode.ExtensionContext) {
 }
 
 export function activate(context: vscode.ExtensionContext) {
+  ctx = context;
   return dynamicImportAndActivate(context).catch((e) => {
     console.log("Error activating extension: ", e);
     Telemetry.capture(
@@ -45,7 +48,8 @@ export function activate(context: vscode.ExtensionContext) {
   });
 }
 
-export function deactivate() {
+export async function deactivate() {
+  const start = Date.now();
   Telemetry.capture(
     "deactivate",
     {
@@ -53,6 +57,11 @@ export function deactivate() {
     },
     true,
   );
-
   Telemetry.shutdownPosthogClient();
+  if (ctx) {
+    const { deactivate } = await import("./activation/activate");
+    await deactivate(ctx);
+  }
+  const elapsed = Date.now() - start;
+  console.log(`Deactivating done in ${elapsed} ms`);
 }

--- a/extensions/vscode/src/granite/ollama/ollamaServer.ts
+++ b/extensions/vscode/src/granite/ollama/ollamaServer.ts
@@ -474,6 +474,27 @@ export class OllamaServer implements IModelServer, Disposable {
     return modelInfo || DEFAULT_MODEL_INFO.get(modelName);
   }
 
+  /**
+   * Unload model from ollama server, see https://github.com/ollama/ollama/blob/main/docs/api.md#unload-a-model
+   * @param model - The model to unload
+   */
+  async unloadModel(model: string): Promise<void> {
+    const response = await fetch(`${this.serverUrl}/api/generate`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ model, keep_alive: 0 }),
+    });
+    if (!response.ok) {
+      const errorText = await response.text();
+      throw new Error(
+        `Failed to unload model ${model}: ${response.status} ${response.statusText} - ${errorText}`,
+      );
+    }
+    console.log(`Unloaded ${model}`);
+  }
+
   private async fetchModelInfo(
     modelName: string,
     signal?: AbortSignal,


### PR DESCRIPTION
Unloads Ollama models on VS Code/extension shutdown, the simple way. Model memory is reclaimed immediately after shutdown:

https://github.com/user-attachments/assets/814b2152-4a0a-459f-9785-057614620604

The less simple way would be to collect all LLM providers that support unloading models, then delegate unloading to them. I'll see if there's a proper way to do that in upstream continue.

Fixes https://github.com/Granite-Code/granite-code/issues/136
