### PR TITLE
feat: support virtual slugs in configuration

### DIFF
--- a/core/config/yaml/GraniteCodeRegistryClient.ts
+++ b/core/config/yaml/GraniteCodeRegistryClient.ts
@@ -1,6 +1,6 @@
 import {
   FullSlug,
-  IgnoredBlockControlFlow,
+  IgnoredBlockException,
   PackageIdentifier,
   Registry,
 } from "@continuedev/config-yaml";
@@ -62,7 +62,9 @@ export class GraniteCodeRegistryClient implements Registry {
       // The slug is not recognized, but we don't want to throw an error
       // because it might be a valid slug from a more recent Granite.Code version,
       // we just ignore it.
-      throw IgnoredBlockControlFlow;
+      throw new IgnoredBlockException(
+        `Ignoring unknown granite-code model ${id}`,
+      );
     }
     throw new Error(`Block ${id} is not supported`);
   }

--- a/core/config/yaml/GraniteCodeRegistryClient.ts
+++ b/core/config/yaml/GraniteCodeRegistryClient.ts
@@ -1,0 +1,69 @@
+import {
+  FullSlug,
+  IgnoredBlockControlFlow,
+  PackageIdentifier,
+  Registry,
+} from "@continuedev/config-yaml";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { IdeInfo } from "../..";
+import { getVirtualConfigYamlContent } from "./VirtualConfigYamlSupport";
+
+interface GraniteCodeRegistryClientConfig {
+  rootPath?: string;
+  ideInfo: IdeInfo;
+}
+
+export class GraniteCodeRegistryClient implements Registry {
+  private readonly rootPath?: string;
+  private readonly ideInfo: IdeInfo;
+  constructor(private readonly config: GraniteCodeRegistryClientConfig) {
+    this.rootPath = config.rootPath;
+    this.ideInfo = config.ideInfo;
+  }
+
+  async getContent(id: PackageIdentifier): Promise<string> {
+    switch (id.uriType) {
+      case "file":
+        return this.getContentFromFilePath(id.filePath);
+      case "slug":
+        return this.getContentFromSlug(id.fullSlug);
+      default:
+        throw new Error(
+          `Unknown package identifier type: ${(id as any).uriType}`,
+        );
+    }
+  }
+
+  private getContentFromFilePath(filepath: string): string {
+    if (filepath.startsWith("file://")) {
+      // For Windows file:///C:/path/to/file, we need to handle it properly
+      // On other systems, we might have file:///path/to/file
+      return fs.readFileSync(new URL(filepath), "utf8");
+    } else if (path.isAbsolute(filepath)) {
+      return fs.readFileSync(filepath, "utf8");
+    } else if (this.rootPath) {
+      return fs.readFileSync(path.join(this.rootPath, filepath), "utf8");
+    } else {
+      throw new Error("No rootPath provided for relative file path");
+    }
+  }
+
+  private async getContentFromSlug(fullSlug: FullSlug): Promise<string> {
+    const id = `${fullSlug.ownerSlug}/${fullSlug.packageSlug}/${fullSlug.versionSlug}`;
+    if (id.startsWith("$granite-code/models/")) {
+      const content = getVirtualConfigYamlContent(
+        id,
+        this.ideInfo.extensionVersion,
+      );
+      if (content) {
+        return content;
+      }
+      // The slug is not recognized, but we don't want to throw an error
+      // because it might be a valid slug from a more recent Granite.Code version,
+      // we just ignore it.
+      throw IgnoredBlockControlFlow;
+    }
+    throw new Error(`Block ${id} is not supported`);
+  }
+}

--- a/core/config/yaml/VirtualConfigYamlSupport.ts
+++ b/core/config/yaml/VirtualConfigYamlSupport.ts
@@ -17,25 +17,29 @@ export function getVirtualConfigYamlContent(
   switch (slug) {
     case "$granite-code/models/chat":
       return getVirtualConfig(
-        "Granite Code Chat [Read-only]",
+        getTitle("Chat"),
         DEFAULT_MODEL_GRANITE_LARGE,
         extensionVersion,
       );
     case "$granite-code/models/autocomplete":
       return getVirtualConfig(
-        "Granite Code Autocomplete [Read-only]",
+        getTitle("Autocomplete"),
         DEFAULT_GRANITE_COMPLETION_MODEL,
         extensionVersion,
       );
     case "$granite-code/models/embeddings":
       return getVirtualConfig(
-        "Granite Code Embeddings [Read-only]",
+        getTitle("Embeddings"),
         DEFAULT_GRANITE_EMBEDDING_MODEL,
         extensionVersion,
       );
     default:
       return undefined;
   }
+}
+
+function getTitle(role: string): string {
+  return `Granite Code ${role} [Read-only]`;
 }
 
 const keyOrder = [

--- a/core/config/yaml/VirtualConfigYamlSupport.ts
+++ b/core/config/yaml/VirtualConfigYamlSupport.ts
@@ -1,0 +1,81 @@
+import { graniteCodeModelSlugs } from "@continuedev/config-yaml";
+import * as YAML from "yaml";
+import {
+  DEFAULT_GRANITE_COMPLETION_MODEL,
+  DEFAULT_GRANITE_EMBEDDING_MODEL,
+  DEFAULT_MODEL_GRANITE_LARGE,
+} from "../default";
+
+export function isSupportedSlug(slug: string): boolean {
+  return graniteCodeModelSlugs.includes(slug);
+}
+
+export function getVirtualConfigYamlContent(
+  slug: string,
+  extensionVersion: string = "1.0.0",
+): string | undefined {
+  switch (slug) {
+    case "$granite-code/models/chat":
+      return getVirtualConfig(
+        "Granite Code Chat [Read-only]",
+        DEFAULT_MODEL_GRANITE_LARGE,
+        extensionVersion,
+      );
+    case "$granite-code/models/autocomplete":
+      return getVirtualConfig(
+        "Granite Code Autocomplete [Read-only]",
+        DEFAULT_GRANITE_COMPLETION_MODEL,
+        extensionVersion,
+      );
+    case "$granite-code/models/embeddings":
+      return getVirtualConfig(
+        "Granite Code Embeddings [Read-only]",
+        DEFAULT_GRANITE_EMBEDDING_MODEL,
+        extensionVersion,
+      );
+    default:
+      return undefined;
+  }
+}
+
+const keyOrder = [
+  "name",
+  "model",
+  "provider",
+  "defaultCompletionOptions",
+  "roles",
+];
+const keyOrderMap = new Map(keyOrder.map((k, i) => [k, i]));
+
+function getVirtualConfig(
+  name: string,
+  model: any,
+  extensionVersion: string,
+): string {
+  const serializedModel = YAML.stringify(model, {
+    sortMapEntries: (a, b) => {
+      const aKey = String(a.key);
+      const bKey = String(b.key);
+      const aIndex = keyOrderMap.get(aKey) ?? -1;
+      const bIndex = keyOrderMap.get(bKey) ?? -1;
+      if (aIndex === -1 && bIndex === -1) {
+        return aKey.localeCompare(bKey);
+      }
+      if (aIndex === -1) {
+        return 1;
+      }
+      if (bIndex === -1) {
+        return -1;
+      }
+      return aIndex - bIndex;
+    },
+  });
+
+  return `name: ${name}
+version: ${extensionVersion}
+schema: v1
+
+models:
+  - ${serializedModel.replaceAll("\n", "\n    ").trimEnd()}
+`;
+}

--- a/core/config/yaml/loadYaml.ts
+++ b/core/config/yaml/loadYaml.ts
@@ -7,7 +7,6 @@ import {
   MCPServer,
   ModelRole,
   PackageIdentifier,
-  RegistryClient,
   Rule,
   TEMPLATE_VAR_REGEX,
   unrollAssistant,
@@ -37,7 +36,6 @@ import { modifyAnyConfigWithSharedConfig } from "../sharedConfig";
 
 import { convertPromptBlockToSlashCommand } from "../../commands/slash/promptBlockSlashCommand";
 import { slashCommandFromPromptFile } from "../../commands/slash/promptFileSlashCommand";
-import { getControlPlaneEnvSync } from "../../control-plane/env";
 import { getToolsForIde } from "../../tools";
 import { getCleanUriPath } from "../../util/uri";
 import {
@@ -45,6 +43,7 @@ import {
   defaultConfigGraniteSmall,
 } from "../default";
 import { getAllDotContinueDefinitionFiles } from "../loadLocalAssistants";
+import { GraniteCodeRegistryClient } from "./GraniteCodeRegistryClient";
 import { LocalPlatformClient } from "./LocalPlatformClient";
 import { llmsFromModelConfig } from "./models";
 
@@ -133,10 +132,8 @@ async function loadConfigYaml(options: {
     // This is how we allow use of blocks locally
     const unrollResult = await unrollAssistant(
       packageIdentifier,
-      new RegistryClient({
-        accessToken: await controlPlaneClient.getAccessToken(),
-        apiBase: getControlPlaneEnvSync(ideSettings.continueTestEnvironment)
-          .CONTROL_PLANE_URL,
+      new GraniteCodeRegistryClient({
+        ideInfo: await ide.getIdeInfo(),
         rootPath,
       }),
       {

--- a/core/config/yaml/loadYaml.ts
+++ b/core/config/yaml/loadYaml.ts
@@ -474,7 +474,7 @@ function getAllModels(
     }
   }
 
-  return allModels;
+  return allModels.filter((model) => model.enabled !== false);
 }
 
 function getAllContextProviders(

--- a/extensions/vscode/src/activation/activate.ts
+++ b/extensions/vscode/src/activation/activate.ts
@@ -39,7 +39,7 @@ export async function activateExtension(context: vscode.ExtensionContext) {
   }
 
   // Register config.yaml schema by removing old entries and adding new one (uri.fsPath changes with each version)
-  const yamlMatcher = ".continue/**/*.yaml";
+  const yamlMatcher = ".granite-code*/**/*.yaml";
   const yamlConfig = vscode.workspace.getConfiguration("yaml");
 
   const newPath = path.join(

--- a/extensions/vscode/src/extension/ConfigYamlDefinitionProvider.ts
+++ b/extensions/vscode/src/extension/ConfigYamlDefinitionProvider.ts
@@ -1,0 +1,35 @@
+import * as vscode from "vscode";
+
+import { parseUsesSlug } from "./parseUsesSlug";
+import { getVirtualConfigUri } from "./VirtualConfigUris";
+
+export function registerConfigYamlDefinitionProvider(): vscode.Disposable {
+  return vscode.languages.registerDefinitionProvider(
+    { language: "yaml" },
+    new ConfigYamlDefinitionProvider(),
+  );
+}
+
+class ConfigYamlDefinitionProvider implements vscode.DefinitionProvider {
+  async provideDefinition(
+    document: vscode.TextDocument,
+    position: vscode.Position,
+    _token: vscode.CancellationToken,
+  ): Promise<vscode.Location[] | undefined> {
+    const line = document.lineAt(position.line);
+    const slug = parseUsesSlug(line.text, position.character);
+    if (!slug) {
+      return undefined;
+    }
+
+    const virtualUri = await getVirtualConfigUri(slug);
+    if (!virtualUri) {
+      return undefined;
+    }
+    const location = new vscode.Location(
+      vscode.Uri.parse(virtualUri),
+      new vscode.Position(0, 0),
+    );
+    return [location];
+  }
+}

--- a/extensions/vscode/src/extension/ConfigYamlDefinitionProvider.ts
+++ b/extensions/vscode/src/extension/ConfigYamlDefinitionProvider.ts
@@ -22,7 +22,7 @@ class ConfigYamlDefinitionProvider implements vscode.DefinitionProvider {
       return undefined;
     }
 
-    const virtualUri = await getVirtualConfigUri(slug);
+    const virtualUri = getVirtualConfigUri(slug);
     if (!virtualUri) {
       return undefined;
     }

--- a/extensions/vscode/src/extension/ConfigYamlDiagnosticsProvider.ts
+++ b/extensions/vscode/src/extension/ConfigYamlDiagnosticsProvider.ts
@@ -1,0 +1,80 @@
+import { isSupportedSlug } from "core/config/yaml/VirtualConfigYamlSupport";
+import * as vscode from "vscode";
+
+import { findSlug } from "./parseUsesSlug";
+
+export function registerConfigYamlDiagnosticsProvider(): vscode.Disposable {
+  const diagnosticCollection = vscode.languages.createDiagnosticCollection(
+    "granite-config-yaml",
+  );
+
+  const updateDiagnostics = (document: vscode.TextDocument) => {
+    if (
+      document.languageId !== "yaml" ||
+      !document.uri.fsPath.includes(".granite-code")
+    ) {
+      diagnosticCollection.delete(document.uri);
+      return;
+    }
+
+    const diagnostics: vscode.Diagnostic[] = [];
+    let inModelsCollection = false;
+    let modelIndent: number | undefined = undefined;
+
+    for (let i = 0; i < document.lineCount; i++) {
+      const line = document.lineAt(i);
+      const text = line.text;
+      const trimmed = text.trim();
+      if (trimmed === "" || trimmed.startsWith("#")) {
+        continue; // Skip empty lines and comments
+      }
+      // Detect start of models collection
+      if (/^models\s*:/i.test(trimmed)) {
+        inModelsCollection = true;
+        modelIndent = line.firstNonWhitespaceCharacterIndex;
+        continue;
+      }
+      // Detect end of models collection (by indentation)
+      if (
+        inModelsCollection &&
+        modelIndent !== undefined &&
+        line.firstNonWhitespaceCharacterIndex <= modelIndent
+      ) {
+        inModelsCollection = false;
+        modelIndent = undefined;
+      }
+      if (!inModelsCollection) {
+        continue;
+      }
+
+      // Find slug in current line
+      const [slug, index] = findSlug(text);
+      if (
+        slug &&
+        index !== undefined &&
+        slug.startsWith("$granite-code/models/") &&
+        !isSupportedSlug(slug)
+      ) {
+        const range = new vscode.Range(i, index, i, index + slug.length);
+        diagnostics.push(
+          new vscode.Diagnostic(
+            range,
+            `Unknown $granite-code model: ${slug}`,
+            vscode.DiagnosticSeverity.Warning,
+          ),
+        );
+      }
+    }
+    diagnosticCollection.set(document.uri, diagnostics);
+  };
+
+  vscode.workspace.onDidOpenTextDocument(updateDiagnostics);
+  vscode.workspace.onDidChangeTextDocument((e) =>
+    updateDiagnostics(e.document),
+  );
+  vscode.workspace.textDocuments.forEach(updateDiagnostics);
+
+  return {
+    dispose: () => diagnosticCollection.dispose(),
+  };
+}

--- a/extensions/vscode/src/extension/ConfigYamlDocumentLinkProvider.ts
+++ b/extensions/vscode/src/extension/ConfigYamlDocumentLinkProvider.ts
@@ -2,14 +2,16 @@ import * as path from "path";
 
 import * as vscode from "vscode";
 
+import { getVirtualConfigUri } from "./VirtualConfigUris";
+
 export class ConfigYamlDocumentLinkProvider
   implements vscode.DocumentLinkProvider
 {
   private usesPattern = /^\s*#?\s*-\s*uses:\s*(.+)$/;
-  provideDocumentLinks(
+  async provideDocumentLinks(
     document: vscode.TextDocument,
     token: vscode.CancellationToken,
-  ): vscode.ProviderResult<vscode.DocumentLink[]> {
+  ): Promise<vscode.DocumentLink[]> {
     const links: vscode.DocumentLink[] = [];
 
     for (let lineIndex = 0; lineIndex < document.lineCount; lineIndex++) {
@@ -56,6 +58,12 @@ export class ConfigYamlDocumentLinkProvider
           const parentPath = path.dirname(currentFilePath);
           const resolvedPath = path.resolve(parentPath, slug);
           linkUri = vscode.Uri.file(resolvedPath);
+        } else if (slug.startsWith("$")) {
+          let virtualUri = await getVirtualConfigUri(slug);
+          if (!virtualUri) {
+            continue;
+          }
+          linkUri = vscode.Uri.parse(virtualUri);
         } else {
           linkUri = vscode.Uri.parse(`https://hub.continue.dev/${slug}`);
         }

--- a/extensions/vscode/src/extension/ConfigYamlHoverProvider.ts
+++ b/extensions/vscode/src/extension/ConfigYamlHoverProvider.ts
@@ -27,7 +27,7 @@ class ConfigYamlHoverProvider implements vscode.HoverProvider {
       return undefined;
     }
 
-    const hoverContent = await getVirtualConfigYamlContent(
+    const hoverContent = getVirtualConfigYamlContent(
       slug,
       getExtensionVersion(),
     );

--- a/extensions/vscode/src/extension/ConfigYamlHoverProvider.ts
+++ b/extensions/vscode/src/extension/ConfigYamlHoverProvider.ts
@@ -1,0 +1,47 @@
+import { getVirtualConfigYamlContent } from "core/config/yaml/VirtualConfigYamlSupport";
+import * as vscode from "vscode";
+
+import { getExtensionVersion } from "../util/util";
+
+import { parseUsesSlug } from "./parseUsesSlug";
+
+export function registerConfigYamlHoverProvider(): vscode.Disposable {
+  return vscode.languages.registerHoverProvider(
+    { language: "yaml" },
+    new ConfigYamlHoverProvider(),
+  );
+}
+
+class ConfigYamlHoverProvider implements vscode.HoverProvider {
+  async provideHover(
+    document: vscode.TextDocument,
+    position: vscode.Position,
+    token: vscode.CancellationToken,
+  ): Promise<vscode.Hover | undefined> {
+    if (!document.uri.path.includes(".granite-code")) {
+      return undefined;
+    }
+    const line = document.lineAt(position.line);
+    const slug = parseUsesSlug(line.text, position.character);
+    if (!slug) {
+      return undefined;
+    }
+
+    const hoverContent = await getVirtualConfigYamlContent(
+      slug,
+      getExtensionVersion(),
+    );
+    if (!hoverContent) {
+      return undefined;
+    }
+
+    return {
+      contents: [
+        {
+          language: "yaml",
+          value: hoverContent,
+        },
+      ],
+    };
+  }
+}

--- a/extensions/vscode/src/extension/VirtualConfigUris.ts
+++ b/extensions/vscode/src/extension/VirtualConfigUris.ts
@@ -2,9 +2,7 @@ import { isSupportedSlug } from "core/config/yaml/VirtualConfigYamlSupport";
 
 export const GRANITE_CODE_CONFIG_SCHEME = "granitecode-config";
 
-export async function getVirtualConfigUri(
-  slug: string,
-): Promise<string | undefined> {
+export function getVirtualConfigUri(slug: string): string | undefined {
   if (!isSupportedSlug(slug)) {
     return undefined;
   }

--- a/extensions/vscode/src/extension/VirtualConfigUris.ts
+++ b/extensions/vscode/src/extension/VirtualConfigUris.ts
@@ -1,0 +1,12 @@
+import { isSupportedSlug } from "core/config/yaml/VirtualConfigYamlSupport";
+
+export const GRANITE_CODE_CONFIG_SCHEME = "granitecode-config";
+
+export async function getVirtualConfigUri(
+  slug: string,
+): Promise<string | undefined> {
+  if (!isSupportedSlug(slug)) {
+    return undefined;
+  }
+  return `${GRANITE_CODE_CONFIG_SCHEME}:${encodeURIComponent(`${slug}.yaml`)}`;
+}

--- a/extensions/vscode/src/extension/VirtualConfigYamlDocumentProvider.ts
+++ b/extensions/vscode/src/extension/VirtualConfigYamlDocumentProvider.ts
@@ -1,0 +1,45 @@
+import { getVirtualConfigYamlContent } from "core/config/yaml/VirtualConfigYamlSupport";
+import * as vscode from "vscode";
+
+import { getExtensionVersion } from "../util/util";
+
+import { GRANITE_CODE_CONFIG_SCHEME } from "./VirtualConfigUris";
+
+export function registerVirtualConfigDocumentProvider(): vscode.Disposable {
+  return vscode.workspace.registerTextDocumentContentProvider(
+    GRANITE_CODE_CONFIG_SCHEME,
+    new VirtualConfigYamlDocumentProvider(),
+  );
+}
+
+class VirtualConfigYamlDocumentProvider
+  implements vscode.TextDocumentContentProvider
+{
+  private _onDidChange = new vscode.EventEmitter<vscode.Uri>();
+
+  get onDidChange(): vscode.Event<vscode.Uri> {
+    return this._onDidChange.event;
+  }
+
+  async provideTextDocumentContent(
+    uri: vscode.Uri,
+    token: vscode.CancellationToken,
+  ): Promise<string> {
+    let slug = uri.path;
+    if (slug.endsWith(".yaml")) {
+      slug = slug.slice(0, -5); // Remove the .yaml extension
+    }
+    const content = await getVirtualConfigYamlContent(
+      slug,
+      getExtensionVersion(),
+    );
+    if (content) {
+      return content;
+    }
+    return "";
+  }
+
+  update(uri: vscode.Uri): void {
+    this._onDidChange.fire(uri);
+  }
+}

--- a/extensions/vscode/src/extension/VirtualConfigYamlDocumentProvider.ts
+++ b/extensions/vscode/src/extension/VirtualConfigYamlDocumentProvider.ts
@@ -15,31 +15,19 @@ export function registerVirtualConfigDocumentProvider(): vscode.Disposable {
 class VirtualConfigYamlDocumentProvider
   implements vscode.TextDocumentContentProvider
 {
-  private _onDidChange = new vscode.EventEmitter<vscode.Uri>();
-
-  get onDidChange(): vscode.Event<vscode.Uri> {
-    return this._onDidChange.event;
-  }
-
   async provideTextDocumentContent(
     uri: vscode.Uri,
-    token: vscode.CancellationToken,
+    _token: vscode.CancellationToken,
   ): Promise<string> {
     let slug = uri.path;
     if (slug.endsWith(".yaml")) {
       slug = slug.slice(0, -5); // Remove the .yaml extension
     }
-    const content = await getVirtualConfigYamlContent(
-      slug,
-      getExtensionVersion(),
-    );
+    const content = getVirtualConfigYamlContent(slug, getExtensionVersion());
     if (content) {
       return content;
     }
+    console.warn(`No virtual config found for slug: ${slug}!`);
     return "";
-  }
-
-  update(uri: vscode.Uri): void {
-    this._onDidChange.fire(uri);
   }
 }

--- a/extensions/vscode/src/extension/VsCodeExtension.ts
+++ b/extensions/vscode/src/extension/VsCodeExtension.ts
@@ -40,7 +40,10 @@ import { FileSearch } from "../util/FileSearch";
 import { VsCodeIdeUtils } from "../util/ideUtils";
 import { VsCodeIde } from "../VsCodeIde";
 
+import { registerConfigYamlDefinitionProvider } from "./ConfigYamlDefinitionProvider";
 import { ConfigYamlDocumentLinkProvider } from "./ConfigYamlDocumentLinkProvider";
+import { registerConfigYamlHoverProvider } from "./ConfigYamlHoverProvider";
+import { registerVirtualConfigDocumentProvider } from "./VirtualConfigYamlDocumentProvider";
 import { VsCodeMessenger } from "./VsCodeMessenger";
 
 import setupNextEditWindowManager, {
@@ -425,6 +428,11 @@ export class VsCodeExtension {
       new ConfigYamlDocumentLinkProvider(),
     );
     context.subscriptions.push(linkProvider);
+
+    // Register providers for $* slugs in yaml files
+    context.subscriptions.push(registerVirtualConfigDocumentProvider());
+    context.subscriptions.push(registerConfigYamlDefinitionProvider());
+    context.subscriptions.push(registerConfigYamlHoverProvider());
 
     this.ide.onDidChangeActiveTextEditor((filepath) => {
       void this.core.invoke("files/opened", { uris: [filepath] });

--- a/extensions/vscode/src/extension/VsCodeExtension.ts
+++ b/extensions/vscode/src/extension/VsCodeExtension.ts
@@ -41,6 +41,7 @@ import { VsCodeIdeUtils } from "../util/ideUtils";
 import { VsCodeIde } from "../VsCodeIde";
 
 import { registerConfigYamlDefinitionProvider } from "./ConfigYamlDefinitionProvider";
+import { registerConfigYamlDiagnosticsProvider } from "./ConfigYamlDiagnosticsProvider";
 import { ConfigYamlDocumentLinkProvider } from "./ConfigYamlDocumentLinkProvider";
 import { registerConfigYamlHoverProvider } from "./ConfigYamlHoverProvider";
 import { registerVirtualConfigDocumentProvider } from "./VirtualConfigYamlDocumentProvider";
@@ -433,6 +434,7 @@ export class VsCodeExtension {
     context.subscriptions.push(registerVirtualConfigDocumentProvider());
     context.subscriptions.push(registerConfigYamlDefinitionProvider());
     context.subscriptions.push(registerConfigYamlHoverProvider());
+    context.subscriptions.push(registerConfigYamlDiagnosticsProvider());
 
     this.ide.onDidChangeActiveTextEditor((filepath) => {
       void this.core.invoke("files/opened", { uris: [filepath] });

--- a/extensions/vscode/src/extension/parseUsesSlug.ts
+++ b/extensions/vscode/src/extension/parseUsesSlug.ts
@@ -1,18 +1,32 @@
-const USES_PATTERN = /\buses:\s*(.+)$/dg;
+const USES_PATTERN_STRING = "\\buses:\\s*(.+)$";
 
 export function parseUsesSlug(
   lineText: string,
   position?: number,
 ): string | undefined {
+  const [slug, index] = findSlug(lineText, position);
+  if (slug) {
+    return slug;
+  }
+  return undefined;
+}
+
+export function findSlug(
+  lineText: string,
+  position?: number,
+): [string | undefined, number | undefined] {
+  const pattern = new RegExp(USES_PATTERN_STRING, "dg");
   let match;
-  while ((match = USES_PATTERN.exec(lineText)) !== null) {
+  while ((match = pattern.exec(lineText)) !== null) {
     let slug = match[1].trim();
+    let quoteOffset = 0;
 
     // Check for surrounding quotes
-    const quoteMatch = slug.match(/^(['"])(.*)\1/);
+    const quoteMatch = slug.match(/^(['"])(.*?)\1/);
     if (quoteMatch) {
       // If quoted, remove the quotes but keep everything inside (including #)
       slug = quoteMatch[2].trim();
+      quoteOffset = 1; // Add offset to skip the opening quote
     } else {
       // If not quoted, remove any trailing comment
       slug = slug.replace(/\s*#.*$/, "").trim();
@@ -22,16 +36,18 @@ export function parseUsesSlug(
       continue;
     }
 
+    const indices = match.indices![1];
+    const startPosition = indices[0] + quoteOffset;
+    const endPosition = indices[1] - quoteOffset; // don't include potential last quote
     // If a position is provided, check if the slug capture group contains the position
-    if (typeof position === "number") {
-      const indices = match.indices?.[1];
-      if (!indices || position < indices[0] || position > indices[1]) {
-        continue;
-      }
+    if (
+      typeof position === "number" &&
+      (position < startPosition || position >= endPosition)
+    ) {
+      continue;
     }
 
-    return slug;
+    return [slug, startPosition];
   }
-
-  return undefined;
+  return [undefined, undefined];
 }

--- a/extensions/vscode/src/extension/parseUsesSlug.ts
+++ b/extensions/vscode/src/extension/parseUsesSlug.ts
@@ -1,0 +1,39 @@
+const USES_PATTERN = /^\s*#?\s*-\s*uses:\s*(.+)$/;
+
+export function parseUsesSlug(
+  lineText: string,
+  position?: number,
+): string | undefined {
+  const match = USES_PATTERN.exec(lineText);
+  if (!match) {
+    return undefined;
+  }
+  let slug = match[1].trim();
+  // Remove any leading comment symbols (#)
+  slug = slug.replace(/^\s*(#\s*)+/, "");
+
+  // Check for surrounding quotes
+  const quoteMatch = slug.match(/^(['"])(.*)\1/);
+  if (quoteMatch) {
+    // If quoted, remove the quotes but keep everything inside (including #)
+    slug = quoteMatch[2].trim();
+  } else {
+    // If not quoted, remove any trailing comment
+    slug = slug.replace(/\s*#.*$/, "").trim();
+  }
+
+  if (!slug || !slug.startsWith("$")) {
+    return undefined;
+  }
+
+  // If a position is provided, check if the slug is within the line text at that position
+  if (typeof position === "number") {
+    const startPos = lineText.indexOf(slug);
+    const endPos = startPos + slug.length;
+    if (position < startPos || position > endPos) {
+      return undefined;
+    }
+  }
+
+  return slug;
+}

--- a/extensions/vscode/src/extension/parseUsesSlug.ts
+++ b/extensions/vscode/src/extension/parseUsesSlug.ts
@@ -1,39 +1,37 @@
-const USES_PATTERN = /^\s*#?\s*-\s*uses:\s*(.+)$/;
+const USES_PATTERN = /\buses:\s*(.+)$/dg;
 
 export function parseUsesSlug(
   lineText: string,
   position?: number,
 ): string | undefined {
-  const match = USES_PATTERN.exec(lineText);
-  if (!match) {
-    return undefined;
-  }
-  let slug = match[1].trim();
-  // Remove any leading comment symbols (#)
-  slug = slug.replace(/^\s*(#\s*)+/, "");
+  let match;
+  while ((match = USES_PATTERN.exec(lineText)) !== null) {
+    let slug = match[1].trim();
 
-  // Check for surrounding quotes
-  const quoteMatch = slug.match(/^(['"])(.*)\1/);
-  if (quoteMatch) {
-    // If quoted, remove the quotes but keep everything inside (including #)
-    slug = quoteMatch[2].trim();
-  } else {
-    // If not quoted, remove any trailing comment
-    slug = slug.replace(/\s*#.*$/, "").trim();
-  }
-
-  if (!slug || !slug.startsWith("$")) {
-    return undefined;
-  }
-
-  // If a position is provided, check if the slug is within the line text at that position
-  if (typeof position === "number") {
-    const startPos = lineText.indexOf(slug);
-    const endPos = startPos + slug.length;
-    if (position < startPos || position > endPos) {
-      return undefined;
+    // Check for surrounding quotes
+    const quoteMatch = slug.match(/^(['"])(.*)\1/);
+    if (quoteMatch) {
+      // If quoted, remove the quotes but keep everything inside (including #)
+      slug = quoteMatch[2].trim();
+    } else {
+      // If not quoted, remove any trailing comment
+      slug = slug.replace(/\s*#.*$/, "").trim();
     }
+
+    if (!slug || !slug.startsWith("$")) {
+      continue;
+    }
+
+    // If a position is provided, check if the slug capture group contains the position
+    if (typeof position === "number") {
+      const indices = match.indices?.[1];
+      if (!indices || position < indices[0] || position > indices[1]) {
+        continue;
+      }
+    }
+
+    return slug;
   }
 
-  return slug;
+  return undefined;
 }

--- a/extensions/vscode/src/extension/parseUsesSlug.vitest.ts
+++ b/extensions/vscode/src/extension/parseUsesSlug.vitest.ts
@@ -1,0 +1,119 @@
+import { describe, expect, test } from "vitest";
+
+import { findSlug, parseUsesSlug } from "./parseUsesSlug";
+
+describe("parseUsesSlug", () => {
+  test("returns undefined for non-matching lines", () => {
+    expect(parseUsesSlug("foo bar")).toBeUndefined();
+    expect(parseUsesSlug("")).toBeUndefined();
+  });
+
+  test("extracts slug from simple uses line", () => {
+    expect(parseUsesSlug("uses: $granite-code/models/foo")).toBe(
+      "$granite-code/models/foo",
+    );
+  });
+
+  test("extracts slug when cursor is within slug", () => {
+    const line = "uses: $granite-code/models/foo";
+    expect(parseUsesSlug(line, 20)).toBe("$granite-code/models/foo");
+  });
+
+  test("returns undefined when cursor is outside slug", () => {
+    const line = "uses: $granite-code/models/foo";
+    expect(parseUsesSlug(line, 2)).toBeUndefined();
+  });
+});
+
+describe("findSlug", () => {
+  test("finds unquoted slug", () => {
+    const [slug, position] = findSlug("uses: $granite-code/models/foo");
+    expect(slug).toBe("$granite-code/models/foo");
+    expect(position).toBe(6);
+  });
+
+  test("finds quoted slug", () => {
+    const [slug, position] = findSlug('uses: "$granite-code/models/foo"');
+    expect(slug).toBe("$granite-code/models/foo");
+    expect(position).toBe(7);
+  });
+
+  test("Handle multiple quotes", () => {
+    const [slug, position] = findSlug(
+      'uses: "$granite-code/models/foo" # Use " just because',
+    );
+    expect(slug).toBe("$granite-code/models/foo");
+    expect(position).toBe(7);
+  });
+
+  test("handles single quotes", () => {
+    const [slug, position] = findSlug("uses: '$granite-code/models/foo'");
+    expect(slug).toBe("$granite-code/models/foo");
+    expect(position).toBe(7);
+  });
+
+  test("ignores comments in unquoted slugs", () => {
+    const [slug, position] = findSlug(
+      "uses: $granite-code/models/foo # comment",
+    );
+    expect(slug).toBe("$granite-code/models/foo");
+    expect(position).toBe(6);
+  });
+
+  test("preserves comments in quoted slugs", () => {
+    const [slug, position] = findSlug(
+      'uses: "$granite-code/models/foo # not a comment"',
+    );
+    expect(slug).toBe("$granite-code/models/foo # not a comment");
+    expect(position).toBe(7);
+  });
+
+  test("ignores non-$ prefixed values", () => {
+    const [slug, position] = findSlug("uses: granite-code/models/foo");
+    expect(slug).toBeUndefined();
+    expect(position).toBeUndefined();
+  });
+
+  test("handles position checks", () => {
+    const line = "uses: $granite-code/models/foo";
+    // Position within slug
+    expect(findSlug(line, 20)[0]).toBe("$granite-code/models/foo");
+    // Position before slug
+    expect(findSlug(line, 2)[0]).toBeUndefined();
+    // Position after slug
+    expect(findSlug(line, 30)[0]).toBeUndefined();
+  });
+
+  test("handles position checks", () => {
+    const line = "uses: '$granite-code/models/foo'";
+    // Position within slug
+    expect(findSlug(line, 7)[0]).toBe("$granite-code/models/foo");
+    // Position before slug
+    expect(findSlug(line, 6)[0]).toBeUndefined();
+    // Position after slug
+    expect(findSlug(line, 31)[0]).toBeUndefined();
+  });
+
+  test("returns undefined for non-matching lines", () => {
+    const [slug, position] = findSlug("not a uses line");
+    expect(slug).toBeUndefined();
+    expect(position).toBeUndefined();
+  });
+
+  test("finds correct slug when multiple slugs exist on same line", () => {
+    const line =
+      "foo: $granite-code/models/autocomplete uses: $granite-code/models/foo";
+    const [slug, position] = findSlug(line);
+    expect(slug).toBe("$granite-code/models/foo");
+    expect(position).toBe(45);
+  });
+
+  test("handles position check with multiple slugs on same line", () => {
+    const line =
+      "foo: $granite-code/models/autocomplete uses: $granite-code/models/foo";
+    // Position in first slug - should not match
+    expect(findSlug(line, 10)[0]).toBeUndefined();
+    // Position in correct slug - should match
+    expect(findSlug(line, 48)[0]).toBe("$granite-code/models/foo");
+  });
+});

--- a/packages/config-yaml/src/browser.ts
+++ b/packages/config-yaml/src/browser.ts
@@ -12,6 +12,7 @@ export * from "./load/unroll.js";
 export * from "./markdown/index.js";
 export * from "./modelName.js";
 // Note: registryClient.js is excluded because it uses Node.js fs/path APIs
+export * from "./schemas/commonSlugs.js";
 export * from "./schemas/data/index.js";
 export * from "./schemas/index.js";
 export * from "./schemas/models.js";

--- a/packages/config-yaml/src/load/unroll.ts
+++ b/packages/config-yaml/src/load/unroll.ts
@@ -26,7 +26,12 @@ import {
 } from "./clientRender.js";
 import { BlockType, getBlockType } from "./getBlockType.js";
 
-export const IgnoredBlockControlFlow = { type: "IgnoredBlockControlFlow" };
+export class IgnoredBlockException extends Error {
+  override name: "IgnoredBlockException" = "IgnoredBlockException";
+  constructor(msg?: string) {
+    super(msg);
+  }
+}
 
 export function parseConfigYaml(configYaml: string): ConfigYaml {
   try {
@@ -345,7 +350,7 @@ export async function unrollBlocks(
             }
             return { index, block: null, error: null };
           } catch (err: any) {
-            if (err.type === IgnoredBlockControlFlow.type) {
+            if (err instanceof IgnoredBlockException) {
               return {
                 index,
                 block: null,
@@ -394,7 +399,11 @@ export async function unrollBlocks(
       }
     }
 
-    return { section, blocks: sectionBlocks, errors: sectionErrors };
+    return {
+      section,
+      blocks: sectionBlocks.filter((b) => b !== undefined),
+      errors: sectionErrors,
+    };
   });
 
   // Process rules in parallel
@@ -473,7 +482,7 @@ export async function unrollBlocks(
               error: null,
             };
           } catch (err: any) {
-            if (err.type === IgnoredBlockControlFlow.type) {
+            if (err instanceof IgnoredBlockException) {
               return {};
             }
             let msg = "";

--- a/packages/config-yaml/src/load/unroll.ts
+++ b/packages/config-yaml/src/load/unroll.ts
@@ -26,6 +26,8 @@ import {
 } from "./clientRender.js";
 import { BlockType, getBlockType } from "./getBlockType.js";
 
+export const IgnoredBlockControlFlow = { type: "IgnoredBlockControlFlow" };
+
 export function parseConfigYaml(configYaml: string): ConfigYaml {
   try {
     const parsed = YAML.parse(configYaml);
@@ -342,7 +344,14 @@ export async function unrollBlocks(
               };
             }
             return { index, block: null, error: null };
-          } catch (err) {
+          } catch (err: any) {
+            if (err.type === IgnoredBlockControlFlow.type) {
+              return {
+                index,
+                block: null,
+                error: null,
+              };
+            }
             let msg = "";
             if (
               typeof unrolledBlock.uses !== "string" &&
@@ -380,7 +389,9 @@ export async function unrollBlocks(
       if (result.error) {
         sectionErrors.push(result.error);
       }
-      sectionBlocks[result.index] = result.block;
+      if (result.block) {
+        sectionBlocks[result.index] = result.block;
+      }
     }
 
     return { section, blocks: sectionBlocks, errors: sectionErrors };
@@ -461,7 +472,10 @@ export async function unrollBlocks(
                   : undefined,
               error: null,
             };
-          } catch (err) {
+          } catch (err: any) {
+            if (err.type === IgnoredBlockControlFlow.type) {
+              return {};
+            }
             let msg = "";
             if (injectBlock.uriType === "file") {
               msg = `${(err as Error).message}.\n> ${injectBlock.filePath}`;

--- a/packages/config-yaml/src/schemas/commonSlugs.ts
+++ b/packages/config-yaml/src/schemas/commonSlugs.ts
@@ -28,3 +28,9 @@ export const commonModelSlugs = [
   "ollama/deepseek-r1-8b",
   "openai/text-embedding-3-large",
 ];
+
+export const graniteCodeModelSlugs = [
+  "$granite-code/models/chat",
+  "$granite-code/models/autocomplete",
+  "$granite-code/models/embeddings",
+];

--- a/packages/config-yaml/src/schemas/index.ts
+++ b/packages/config-yaml/src/schemas/index.ts
@@ -1,5 +1,5 @@
 import * as z from "zod";
-import { commonModelSlugs } from "./commonSlugs.js";
+import { graniteCodeModelSlugs } from "./commonSlugs.js";
 import { dataSchema } from "./data/index.js";
 import {
   modelSchema,
@@ -114,7 +114,9 @@ export const baseConfigYamlSchema = z.object({
 
 const modelsUsesSchema = z
   .string()
-  .or(z.enum(commonModelSlugs as [string, ...string[]]));
+  // Continue's commonModelSlugs are actually unavailable,
+  // so replace them with graniteCodeModelSlugs
+  .or(z.enum(graniteCodeModelSlugs as [string, ...string[]]));
 
 export const configYamlSchema = baseConfigYamlSchema.extend({
   models: z

--- a/packages/config-yaml/src/schemas/models.ts
+++ b/packages/config-yaml/src/schemas/models.ts
@@ -145,6 +145,7 @@ const baseModelFields = {
   chatOptions: chatOptionsSchema.optional(),
   promptTemplates: promptTemplatesSchema.optional(),
   useLegacyCompletionsEndpoint: z.boolean().optional(),
+  enabled: z.boolean().optional(),
   env: z
     .record(z.string(), z.union([z.string(), z.boolean(), z.number()]))
     .optional(),


### PR DESCRIPTION
Add support for $granite-code/models/* virtual model configs. They can be used and overridden like:

```yaml
models:
  - uses: $granite-code/models/chat
    override: 
      apiBase: http://remote.host:11434
```

YAML Schema is enabled on .granite-code* paths, so both validation and completion (of `uses:`) can work.

Continue's remote slug support is removed (it didn't work anyway)

virtual model config support includes:
- Cmd+Click navigation to a read-only page showing the actual values used by Granite-Code for a given model
- Hover shows the same contents as the above read-only page
- Go to / Peek definition works to display the same content as the above

Unknown $granite-code/models/*  are ignored so that a config file created by a newer version of granite-code won't break older versions. Think different versions of granite-code running in parallel on different flavors of VS Code (e.g. Insiders, VS Codium, ...)

## Screenshots

Hover on slug:
<img width="422" alt="Screenshot 2025-07-09 at 15 22 52" src="https://github.com/user-attachments/assets/9a086c79-a3cb-4262-a30e-951ffde68bd0" />

Peek definition on slug:
<img width="1198" alt="Screenshot 2025-07-09 at 15 23 40" src="https://github.com/user-attachments/assets/27344cb6-f3f1-4de5-8c8b-1903dd121e8c" />

Slug completion:
<img width="586" alt="Screenshot 2025-07-09 at 14 14 00" src="https://github.com/user-attachments/assets/c4723cd1-9bc3-4ef1-9700-db9c3c35ed7e" />
