### PR TITLE
pruned out references to Continue docs and replace with Granite.Code docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,12 +20,6 @@ and [hub of models, rules, prompts, docs, and other building blocks](https://hub
 <a target="_blank" href="https://opensource.org/licenses/Apache-2.0" style="background:none">
     <img src="https://img.shields.io/badge/License-Apache_2.0-blue.svg" style="height: 22px;" />
 </a>
-<a target="_blank" href="https://docs.continue.dev" style="background:none">
-    <img src="https://img.shields.io/badge/continue_docs-%23BE1B55" style="height: 22px;" />
-</a>
-<a target="_blank" href="https://changelog.continue.dev" style="background:none">
-    <img src="https://img.shields.io/badge/changelog-%96EFF3" style="height: 22px;" />
-</a>
 <a target="_blank" href="https://discord.gg/vapESyrFmJ" style="background:none">
     <img src="https://img.shields.io/badge/discord-join-continue.svg?labelColor=191937&color=6F6FF7&logo=discord" style="height: 22px;" />
 </a>

--- a/core/config/workspace/workspaceBlocks.ts
+++ b/core/config/workspace/workspaceBlocks.ts
@@ -53,7 +53,7 @@ function getContentsForNewBlock(blockType: BlockType): ConfigYaml {
       configYaml.docs = [
         {
           name: "New docs",
-          startUrl: "https://docs.continue.dev",
+          startUrl: "https://docs.granitecode.ai",
         },
       ];
       break;

--- a/core/config/workspace/workspaceBlocks.vitest.ts
+++ b/core/config/workspace/workspaceBlocks.vitest.ts
@@ -27,7 +27,7 @@ describe("getFileContent", () => {
     const docsResult = getFileContent("docs");
     expect(docsResult).toContain("name: New doc");
     expect(docsResult).toContain("docs:");
-    expect(docsResult).toContain("startUrl: https://docs.continue.dev");
+    expect(docsResult).toContain("startUrl: https://docs.granitecode.ai");
 
     const promptsResult = getFileContent("prompts");
     expect(promptsResult).toContain("name: New prompt");

--- a/docs/reference.mdx
+++ b/docs/reference.mdx
@@ -367,8 +367,8 @@ config.yaml
 ```yaml
 docs:
   - name: Continue
-    startUrl: https://docs.continue.dev/intro
-    favicon: https://docs.continue.dev/favicon.ico
+    startUrl:
+    favicon:
 ```
 
 ---

--- a/docs/reference/json-reference.mdx
+++ b/docs/reference/json-reference.mdx
@@ -35,9 +35,7 @@ Each model has specific configuration options tailored to its provider and funct
 - `maxStopWords`: Maximum number of stop words allowed, to avoid API errors with extensive lists.
 
 - `template`: Chat template to format messages. Auto-detected for most models but can be overridden. See intelliJ suggestions.
-
-- `promptTemplates`: A mapping of prompt template names (e.g., `edit`) to template strings. See the [Deep Dives section](/customize/deep-dives/prompts) for customization details.
-
+- `promptTemplates`: A mapping of prompt template names (e.g., `edit`) to template strings.
 - `completionOptions`: Model-specific completion options, same format as top-level [`completionOptions`](#completionoptions), which they override.
 
 - `systemMessage`: A system message that will precede responses from the LLM.
@@ -264,10 +262,14 @@ List of documentation sites to index.
 
 Example
 
-config.json
-
-```
-"docs": [    {    "title": "Continue",    "startUrl": "https://docs.continue.dev/intro",    "faviconUrl": "https://docs.continue.dev/favicon.ico",  }]
+```json title="config.json"
+"docs": [
+    {
+    "title": "Continue",
+    "startUrl": "https://docs.continue.dev/intro",
+    "faviconUrl": "https://docs.continue.dev/favicon.ico",
+  }
+]
 ```
 
 ### `slashCommands`

--- a/extensions/intellij/src/main/resources/continue_tutorial.java
+++ b/extensions/intellij/src/main/resources/continue_tutorial.java
@@ -60,4 +60,4 @@ public static int[] sortingAlgorithm2(int[] x) {
 // 1. Switch from "Chat" to "Agent" mode using the dropdown in the bottom left of the input box
 // 2. Try asking Continue "Write unit tests for this code in a new file and run the test"
 
-// ——————————————————      Learn more at https://docs.continue.dev/getting-started/overview      ——————————————————— //
+// ——————————————————      Learn more at https://docs.granitecode.ai/getting-started      ——————————————————— //

--- a/extensions/intellij/src/main/resources/continue_tutorial.py
+++ b/extensions/intellij/src/main/resources/continue_tutorial.py
@@ -49,4 +49,4 @@ def sorting_algorithm2(x):
 # 1. Switch from "Chat" to "Agent" mode using the dropdown in the bottom left of the input box
 # 2. Try asking Continue "Write unit tests for this code in a new file and run the test"
 
-# ——————————————————      Learn more at https://docs.continue.dev/getting-started/overview      ——————————————————— #
+# ——————————————————      Learn more at https://docs.granitecode.ai/getting-started     ——————————————————— #

--- a/extensions/intellij/src/main/resources/continue_tutorial.ts
+++ b/extensions/intellij/src/main/resources/continue_tutorial.ts
@@ -60,4 +60,4 @@ function sortingAlgorithm2(x: number[]): number[] {
 // 1. Switch from "Chat" to "Agent" mode using the dropdown in the bottom left of the input box
 // 2. Try asking Continue "Write unit tests for this code in a new file"
 
-// ——————————————————      Learn more at https://docs.continue.dev/getting-started/overview      ——————————————————— //
+// ——————————————————      Learn more at https://docs.granitecode.ai/getting-started      ——————————————————— //

--- a/extensions/vscode/README.md
+++ b/extensions/vscode/README.md
@@ -8,7 +8,7 @@
 
 <div align="center">
 
-**[Continue](https://docs.continue.dev) enables to developers create, share, and use custom AI code assistants with our open-source [VS Code](https://marketplace.visualstudio.com/items?itemName=Continue.continue) extension and [hub of models, rules, prompts, docs, and other building blocks](https://hub.continue.dev)**
+**Continue enables to developers create, share, and use custom AI code assistants with our open-source [VS Code](https://marketplace.visualstudio.com/items?itemName=Continue.continue) extension and [hub of models, rules, prompts, docs, and other building blocks](https://hub.continue.dev)**
 
 </div>
 
@@ -16,9 +16,6 @@
 
 <a target="_blank" href="https://opensource.org/licenses/Apache-2.0" style="background:none">
     <img src="https://img.shields.io/badge/License-Apache_2.0-blue.svg" style="height: 22px;" />
-</a>
-<a target="_blank" href="https://docs.continue.dev" style="background:none">
-    <img src="https://img.shields.io/badge/continue_docs-%23BE1B55" style="height: 22px;" />
 </a>
 <a target="_blank" href="https://discord.gg/vapESyrFmJ" style="background:none">
     <img src="https://img.shields.io/badge/discord-join-continue.svg?labelColor=191937&color=6F6FF7&logo=discord" style="height: 22px;" />

--- a/extensions/vscode/continue_tutorial.py
+++ b/extensions/vscode/continue_tutorial.py
@@ -50,4 +50,4 @@ def sorting_algorithm2(x):
 # 2. Try asking Continue "Write unit tests for this code in a new file",
 #    or if you have Python installed, "Write unit tests for this code in a new file and run the test"
 
-# ——————————————————      Learn more at https://docs.continue.dev/getting-started/overview      ——————————————————— #
+# ——————————————————      Learn more at https://docs.granitecode.ai/getting-started      ——————————————————— #

--- a/extensions/vscode/src/autocomplete/completionProvider.ts
+++ b/extensions/vscode/src/autocomplete/completionProvider.ts
@@ -52,15 +52,7 @@ export class ContinueCompletionProvider
     if (e instanceof Error) {
       message += `: ${e.message}`;
     }
-    vscode.window.showErrorMessage(message, "Documentation").then((val) => {
-      if (val === "Documentation") {
-        vscode.env.openExternal(
-          vscode.Uri.parse(
-            "https://docs.continue.dev/features/tab-autocomplete",
-          ),
-        );
-      }
-    });
+    vscode.window.showErrorMessage(message);
   }
 
   private completionProvider: CompletionProvider;

--- a/extensions/vscode/src/webviewProtocol.ts
+++ b/extensions/vscode/src/webviewProtocol.ts
@@ -107,9 +107,9 @@ export class VsCodeWebviewProtocol
 
           if (e.cause) {
             if (e.cause.name === "ConnectTimeoutError") {
-              message = `Connection timed out. If you expect it to take a long time to connect, you can increase the timeout in config.json by setting "requestOptions": { "timeout": 10000 }. You can find the full config reference here: https://docs.continue.dev/reference/config`;
+              message = `Connection timed out. If you expect it to take a long time to connect, you can increase the timeout in config.json by setting "requestOptions": { "timeout": 10000 }.`;
             } else if (e.cause.code === "ECONNREFUSED") {
-              message = `Connection was refused. This likely means that there is no server running at the specified URL. If you are running your own server you may need to set the "apiBase" parameter in config.json. For example, you can set up an OpenAI-compatible server like here: https://docs.continue.dev/reference/Model%20Providers/openai#openai-compatible-servers--apis`;
+              message = `Connection was refused. This likely means that there is no server running at the specified URL. If you are running your own server you may need to set the "apiBase" parameter in config.json.`;
             } else {
               message = `The request failed with "${e.cause.name}": ${e.cause.message}. If you're having trouble setting up Continue, please see the troubleshooting guide for help.`;
             }

--- a/gui/src/forms/AddModelForm.tsx
+++ b/gui/src/forms/AddModelForm.tsx
@@ -20,10 +20,9 @@ interface AddModelFormProps {
   hideFreeTrialLimitMessage?: boolean;
 }
 
-const MODEL_PROVIDERS_URL =
-  "https://docs.continue.dev/customize/model-providers";
+const MODEL_PROVIDERS_URL = "";
 const CODESTRAL_URL = "https://console.mistral.ai/codestral";
-const CONTINUE_SETUP_URL = "https://docs.continue.dev/setup/overview";
+const CONTINUE_SETUP_URL = "";
 
 export function AddModelForm({
   onDone,

--- a/gui/src/pages/AddNewModel/configs/providers.ts
+++ b/gui/src/pages/AddNewModel/configs/providers.ts
@@ -118,7 +118,7 @@ export const providers: Partial<Record<string, ProviderInfo>> = {
     title: "Moonshot",
     provider: "moonshot",
     description: "Use the Moonshot API for LLMs",
-    longDescription: `[Visit our documentation](https://docs.continue.dev/reference/Model%20Providers/moonshot) for information on obtaining an API key.`,
+    longDescription: `Visit the Moonshot documentation for information on obtaining an API key.`,
     icon: "moonshot.png",
     tags: [ModelProviderTags.RequiresApiKey],
     refPage: "moonshot",
@@ -229,7 +229,7 @@ export const providers: Partial<Record<string, ProviderInfo>> = {
     provider: "azure",
     description:
       "Azure OpenAI Service offers industry-leading coding and language AI models that you can fine-tune to your specific needs for a variety of use cases.",
-    longDescription: `[Visit our documentation](https://docs.continue.dev/reference/Model%20Providers/azure) for information on obtaining an API key.
+    longDescription: `Visit the Azure OpenAI documentation for information on obtaining an API key.
 
 Select the \`GPT-4o\` model below to complete your provider configuration, but note that this will not affect the specific model you need to select when creating your Azure deployment.`,
     icon: "azure.png",

--- a/packages/config-yaml/src/validation.ts
+++ b/packages/config-yaml/src/validation.ts
@@ -65,7 +65,7 @@ export function validateConfigYaml(
       ) {
         errors.push({
           fatal: false,
-          message: `${model.model} is not trained for tab-autocomplete, and will result in low-quality suggestions. See the docs to learn more about why: https://docs.continue.dev/features/tab-autocomplete#i-want-better-completions-should-i-use-gpt-4`,
+          message: `${model.model} is not trained for tab-autocomplete, and will result in low-quality suggestions.`,
         });
       }
     }


### PR DESCRIPTION
## Description


pruned out references to Continue docs in:
- generated files (gui/dist/assets/index.js ./binary/out/index.js)
- the docs directory
- config.json and continuerc schemas
- the AddModel dialog

replaced with Granite.Code docs in:

-tutorial files
-core/config/workspace/workspaceBlocks.ts



Resolves: https://github.com/Granite-Code/granite-code/issues/147