### PR TITLE
fix: create new Doc/Rule/Prompt files in ./.granite-code/

### DIFF
--- a/core/config/workspace/workspaceBlocks.ts
+++ b/core/config/workspace/workspaceBlocks.ts
@@ -130,7 +130,10 @@ export async function createNewWorkspaceBlockFile(
     );
   }
 
-  const baseDirUri = joinPathsToUri(workspaceDirs[0], `.continue/${blockType}`);
+  const baseDirUri = joinPathsToUri(
+    workspaceDirs[0],
+    `.granite-code/${blockType}`,
+  );
 
   const fileUri = await findAvailableFilename(
     baseDirUri,


### PR DESCRIPTION
Fix the `+ Add [...]` button behavior so it generates new Doc/Rule/Prompt files in ./.granite-code/ instead of ./.continue/

<img width="479" height="65" alt="Screenshot 2025-07-28 at 17 33 48" src="https://github.com/user-attachments/assets/e44b2459-b848-4999-8b5f-d0c2910a6a16" />

