### PR TITLE
Chore: remove everything related to LocalModelSize

### DIFF
--- a/core/config/default.ts
+++ b/core/config/default.ts
@@ -47,14 +47,7 @@ const BASE_GRANITE_CONFIG: Partial<ModelConfig> = {
   roles: ["apply", "chat", "edit", "summarize"],
 };
 
-export const DEFAULT_MODEL_GRANITE_SMALL: ModelConfig = {
-  name: "granite3.3:2b",
-  provider: "ollama",
-  model: "granite3.3:2b",
-  ...BASE_GRANITE_CONFIG,
-};
-
-export const DEFAULT_MODEL_GRANITE_LARGE: ModelConfig = {
+export const DEFAULT_GRANITE_CHAT_MODEL: ModelConfig = {
   name: "granite3.3:8b",
   provider: "ollama",
   model: "granite3.3:8b",
@@ -85,34 +78,17 @@ export const DEFAULT_GRANITE_EMBEDDING_MODEL: ModelConfig = {
   roles: ["embed"],
 };
 
-export const DEFAULT_GRANITE_MODEL_IDS_LARGE = [
-  DEFAULT_MODEL_GRANITE_LARGE.model,
+export const DEFAULT_GRANITE_MODEL_IDS = [
+  DEFAULT_GRANITE_CHAT_MODEL.model,
   DEFAULT_GRANITE_COMPLETION_MODEL.model,
   DEFAULT_GRANITE_EMBEDDING_MODEL.model,
 ];
 
-export const DEFAULT_GRANITE_MODEL_IDS_SMALL = [
-  DEFAULT_MODEL_GRANITE_SMALL.model,
-  DEFAULT_GRANITE_COMPLETION_MODEL.model,
-  DEFAULT_GRANITE_EMBEDDING_MODEL.model,
-];
-
-export const defaultConfigGraniteLarge: Required<
+export const defaultConfigGranite: Required<
   Pick<AssistantUnrolled, "models" | "context">
 > = {
   models: [
-    DEFAULT_MODEL_GRANITE_LARGE,
-    DEFAULT_GRANITE_COMPLETION_MODEL,
-    DEFAULT_GRANITE_EMBEDDING_MODEL,
-  ],
-  context: defaultContextProvidersVsCode,
-};
-
-export const defaultConfigGraniteSmall: Required<
-  Pick<AssistantUnrolled, "models" | "context">
-> = {
-  models: [
-    DEFAULT_MODEL_GRANITE_SMALL,
+    DEFAULT_GRANITE_CHAT_MODEL,
     DEFAULT_GRANITE_COMPLETION_MODEL,
     DEFAULT_GRANITE_EMBEDDING_MODEL,
   ],

--- a/core/config/types.ts
+++ b/core/config/types.ts
@@ -656,7 +656,6 @@ declare global {
     remoteConfigSyncPeriod: number;
     userToken: string;
     pauseCodebaseIndexOnStart: boolean;
-    localModelSize: LocalModelSize;
   }
   
   export interface IDE {

--- a/core/config/yaml/VirtualConfigYamlSupport.ts
+++ b/core/config/yaml/VirtualConfigYamlSupport.ts
@@ -1,9 +1,9 @@
 import { graniteCodeModelSlugs } from "@continuedev/config-yaml";
 import * as YAML from "yaml";
 import {
+  DEFAULT_GRANITE_CHAT_MODEL,
   DEFAULT_GRANITE_COMPLETION_MODEL,
   DEFAULT_GRANITE_EMBEDDING_MODEL,
-  DEFAULT_MODEL_GRANITE_LARGE,
 } from "../default";
 
 export function isSupportedSlug(slug: string): boolean {
@@ -18,7 +18,7 @@ export function getVirtualConfigYamlContent(
     case "$granite-code/models/chat":
       return getVirtualConfig(
         getTitle("Chat"),
-        DEFAULT_MODEL_GRANITE_LARGE,
+        DEFAULT_GRANITE_CHAT_MODEL,
         extensionVersion,
       );
     case "$granite-code/models/autocomplete":

--- a/core/config/yaml/loadYaml.ts
+++ b/core/config/yaml/loadYaml.ts
@@ -38,10 +38,7 @@ import { convertPromptBlockToSlashCommand } from "../../commands/slash/promptBlo
 import { slashCommandFromPromptFile } from "../../commands/slash/promptFileSlashCommand";
 import { getToolsForIde } from "../../tools";
 import { getCleanUriPath } from "../../util/uri";
-import {
-  defaultConfigGraniteLarge,
-  defaultConfigGraniteSmall,
-} from "../default";
+import { defaultConfigGranite } from "../default";
 import { getAllDotContinueDefinitionFiles } from "../loadLocalAssistants";
 import { GraniteCodeRegistryClient } from "./GraniteCodeRegistryClient";
 import { LocalPlatformClient } from "./LocalPlatformClient";
@@ -262,10 +259,7 @@ async function configYamlToContinueConfig(options: {
     ),
   };
 
-  const graniteConfigYaml =
-    ideSettings.localModelSize === "large"
-      ? defaultConfigGraniteLarge
-      : defaultConfigGraniteSmall;
+  const graniteConfigYaml = defaultConfigGranite;
 
   // Prompt files -
   try {

--- a/core/granite/commons/sysInfo.ts
+++ b/core/granite/commons/sysInfo.ts
@@ -1,4 +1,4 @@
-import { DEFAULT_MODEL_GRANITE_LARGE } from "../../config/default";
+import { DEFAULT_GRANITE_CHAT_MODEL } from "../../config/default";
 import { MODEL_REQUIREMENTS } from "./modelRequirements";
 import { GB } from "./sizeUtils";
 import { SYSTEM_REQUIREMENTS } from "./systemRequirements";
@@ -75,7 +75,7 @@ export function getRecommendedModels(systemInfo: SystemInfo) {
 
 export function shouldRecommendLargeModel(systemInfo: SystemInfo): boolean {
   const modelRequirements =
-    MODEL_REQUIREMENTS[DEFAULT_MODEL_GRANITE_LARGE.model];
+    MODEL_REQUIREMENTS[DEFAULT_GRANITE_CHAT_MODEL.model];
   if (!modelRequirements) return false;
 
   if (isHighEndApple(systemInfo.gpus)) {

--- a/core/granite/commons/wizardState.ts
+++ b/core/granite/commons/wizardState.ts
@@ -1,10 +1,7 @@
-import { LocalModelSize } from "../..";
-
 export const OLLAMA_STEP = 0;
 export const MODELS_STEP = 1;
 export const FINAL_STEP = 2;
 
 export interface WizardState {
   stepStatuses: boolean[];
-  selectedModelSize: LocalModelSize;
 }

--- a/core/index.d.ts
+++ b/core/index.d.ts
@@ -761,15 +761,12 @@ export enum FileType {
   SymbolicLink = 64,
 }
 
-export type LocalModelSize = undefined | "small" | "large";
-
 export interface IdeSettings {
   remoteConfigServerUrl: string | undefined;
   remoteConfigSyncPeriod: number;
   userToken: string;
   continueTestEnvironment: "none" | "production" | "staging" | "local";
   pauseCodebaseIndexOnStart: boolean;
-  localModelSize: LocalModelSize;
 }
 
 export interface FileStats {

--- a/core/indexing/docs/DocsService.skip.ts
+++ b/core/indexing/docs/DocsService.skip.ts
@@ -44,7 +44,6 @@
 //       ideSettings: {} as any,
 //       enableDebugLogs: false,
 //       remoteConfigServerUrl: "",
-//       localModelSize: undefined,
 //     });
 //     configHandler = new ConfigHandler(
 //       ide,

--- a/core/util/filesystem.ts
+++ b/core/util/filesystem.ts
@@ -68,7 +68,6 @@ class FileSystemIde implements IDE {
       userToken: "",
       continueTestEnvironment: "none",
       pauseCodebaseIndexOnStart: false,
-      localModelSize: "large",
     };
   }
 

--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -141,15 +141,6 @@
           "default": 60,
           "description": "The period of time in minutes between automatic syncs."
         },
-        "continue.localModelSize": {
-          "type": "string",
-          "enum": [
-            "small",
-            "large"
-          ],
-          "default": "large",
-          "description": "Whether to use a small or large local model. Small models are faster but less accurate."
-        },
         "continue.checkModelUpdates": {
           "type": "boolean",
           "default": true,

--- a/extensions/vscode/src/VsCodeIde.ts
+++ b/extensions/vscode/src/VsCodeIde.ts
@@ -27,7 +27,6 @@ import type {
   IdeInfo,
   IdeSettings,
   IndexTag,
-  LocalModelSize,
   Location,
   Problem,
   RangeInFile,
@@ -694,7 +693,6 @@ class VsCodeIde implements IDE {
         "pauseCodebaseIndexOnStart",
         false,
       ),
-      localModelSize: settings.get<LocalModelSize>("localModelSize", undefined),
     };
     return ideSettings;
   }

--- a/extensions/vscode/src/extension/VsCodeExtension.ts
+++ b/extensions/vscode/src/extension/VsCodeExtension.ts
@@ -451,10 +451,6 @@ export class VsCodeExtension {
         const settings = await this.ide.getIdeSettings();
         void this.core.invoke("config/ideSettingsUpdate", settings);
       }
-      if (event.affectsConfiguration("continue.localModelSize")) {
-        const settings = await this.ide.getIdeSettings();
-        this.configHandler.updateIdeSettings(settings);
-      }
     });
   }
 

--- a/extensions/vscode/src/granite/ollama/modelUpdater.ts
+++ b/extensions/vscode/src/granite/ollama/modelUpdater.ts
@@ -1,8 +1,4 @@
-import { LocalModelSize } from "core";
-import {
-  DEFAULT_GRANITE_MODEL_IDS_LARGE,
-  DEFAULT_GRANITE_MODEL_IDS_SMALL,
-} from "core/config/default";
+import { DEFAULT_GRANITE_MODEL_IDS } from "core/config/default";
 import { EXTENSION_NAME } from "core/control-plane/env";
 import { ProgressData } from "core/granite/commons/progressData";
 import { ModelStatus } from "core/granite/commons/statuses";
@@ -64,14 +60,7 @@ export class ModelUpdater implements Disposable {
 
   private async checkModelUpdates(): Promise<void> {
     try {
-      const type = workspace
-        .getConfiguration(EXTENSION_NAME)
-        .get<LocalModelSize>("localModelSize", "large");
-      console.log(`Checking for [${type}] model updates...`);
-      const modelsToCheck =
-        type === "large"
-          ? DEFAULT_GRANITE_MODEL_IDS_LARGE
-          : DEFAULT_GRANITE_MODEL_IDS_SMALL;
+      const modelsToCheck = DEFAULT_GRANITE_MODEL_IDS;
 
       const modelsToUpdate = await Promise.all(
         modelsToCheck.map(async (model) => {

--- a/extensions/vscode/src/granite/panels/setupGranitePage.ts
+++ b/extensions/vscode/src/granite/panels/setupGranitePage.ts
@@ -1,10 +1,5 @@
-import { LocalModelSize } from "core";
 import { ConfigHandler } from "core/config/ConfigHandler";
-import {
-  DEFAULT_GRANITE_MODEL_IDS_LARGE,
-  DEFAULT_GRANITE_MODEL_IDS_SMALL,
-} from "core/config/default";
-import { EXTENSION_NAME } from "core/control-plane/env";
+import { DEFAULT_GRANITE_MODEL_IDS } from "core/config/default";
 import { GRANITE_ONBOARDING_INCOMPLETE_KEY } from "core/granite/commons/constants";
 import { ProgressData } from "core/granite/commons/progressData";
 import { ModelStatus, ServerStatus } from "core/granite/commons/statuses";
@@ -25,7 +20,6 @@ import {
   Webview,
   WebviewPanel,
   window,
-  workspace,
 } from "vscode";
 
 import { VsCodeWebviewProtocol } from "../../webviewProtocol";
@@ -338,11 +332,8 @@ export class SetupGranitePage {
 
             await this.publishStatus(webview);
             break;
-          case "selectModels":
-            this.wizardState.selectedModelSize = data.model as LocalModelSize;
-            break;
           case "installModels":
-            await this.installModels(data.model as LocalModelSize, panel);
+            await this.installModels(panel);
             break;
         }
       },
@@ -377,7 +368,7 @@ export class SetupGranitePage {
     );
   }
 
-  private async installModels(modelSize: LocalModelSize, panel: WebviewPanel) {
+  private async installModels(panel: WebviewPanel) {
     // Check if the server is running, if not, start it and wait for it to be ready until timeout is reached
     var { serverState, timeout } = await this.waitUntilOllamaStarts();
     const webview = panel.webview;
@@ -406,11 +397,7 @@ export class SetupGranitePage {
     this.modelInstallCanceller = new CancellationController();
     this._disposables.push(this.modelInstallCanceller);
     try {
-      this.wizardState.selectedModelSize = modelSize;
-      const modelsToPull =
-        modelSize === "large"
-          ? DEFAULT_GRANITE_MODEL_IDS_LARGE
-          : DEFAULT_GRANITE_MODEL_IDS_SMALL;
+      const modelsToPull = DEFAULT_GRANITE_MODEL_IDS;
 
       const result = await this.server.pullModels(
         modelsToPull,
@@ -419,7 +406,6 @@ export class SetupGranitePage {
       );
       await this.publishStatus(webview);
       if (result) {
-        await this.saveSettings(modelSize);
         if (!panel.visible) {
           const selection = await window.showInformationMessage(
             "Granite.Code is ready to be used.",
@@ -485,7 +471,7 @@ export class SetupGranitePage {
 
   async publishStatus(webview: Webview) {
     // console.log("Received fetchStatus msg " + debounceStatus);
-    const modelIds = DEFAULT_GRANITE_MODEL_IDS_LARGE;
+    const modelIds = DEFAULT_GRANITE_MODEL_IDS;
     const [serverState, statusByModel] = await Promise.all([
       this.server.getState(),
       this.getStatusByModel(modelIds),
@@ -525,11 +511,5 @@ export class SetupGranitePage {
 
   private async openUrl(url: string) {
     await commands.executeCommand("vscode.open", Uri.parse(url));
-  }
-
-  async saveSettings(modelSize: LocalModelSize): Promise<void> {
-    console.log("Saving settings for model size: " + modelSize);
-    const config = workspace.getConfiguration(EXTENSION_NAME);
-    await config.update("localModelSize", modelSize, true);
   }
 }

--- a/gui/src/granite/GraniteWizard.tsx
+++ b/gui/src/granite/GraniteWizard.tsx
@@ -1,16 +1,9 @@
-import { LocalModelSize } from "core";
-import {
-  DEFAULT_GRANITE_MODEL_IDS_LARGE,
-  DEFAULT_GRANITE_MODEL_IDS_SMALL,
-} from "core/config/default";
+import { DEFAULT_GRANITE_MODEL_IDS } from "core/config/default";
 import { DEFAULT_MODEL_INFO } from "core/granite/commons/modelInfo";
 import { ProgressData } from "core/granite/commons/progressData";
 import { ServerState } from "core/granite/commons/serverState";
 import { ModelStatus, ServerStatus } from "core/granite/commons/statuses";
-import {
-  shouldRecommendLargeModel,
-  SystemInfo,
-} from "core/granite/commons/sysInfo";
+import { SystemInfo } from "core/granite/commons/sysInfo";
 import { formatSize } from "core/granite/commons/textUtils";
 import {
   checkMinimumServerVersion,
@@ -69,10 +62,6 @@ interface WizardContextProps {
   setInstallationModes: React.Dispatch<
     React.SetStateAction<InstallationMode[]>
   >;
-  preselectedModel: LocalModelSize;
-  setPreselectedModel: React.Dispatch<React.SetStateAction<LocalModelSize>>;
-  selectedModel: LocalModelSize;
-  setSelectedModel: React.Dispatch<React.SetStateAction<LocalModelSize>>;
   statusByModel: Map<string, ModelStatus>;
   setStatusByModel: React.Dispatch<
     React.SetStateAction<Map<string, ModelStatus>>
@@ -137,10 +126,6 @@ export const WizardProvider: React.FC<WizardProviderProps> = ({ children }) => {
   const [installationModes, setInstallationModes] = useState<
     InstallationMode[]
   >([]);
-  const [preselectedModel, setPreselectedModel] =
-    useState<LocalModelSize>("large");
-  const [selectedModel, setSelectedModel] =
-    useState<LocalModelSize>(preselectedModel);
   const [modelInstallationProgress, setModelInstallationProgress] =
     useState<number>(0);
   const [modelInstallationError, setModelInstallationError] = useState<
@@ -173,10 +158,6 @@ export const WizardProvider: React.FC<WizardProviderProps> = ({ children }) => {
         setSystemInfo,
         installationModes,
         setInstallationModes,
-        preselectedModel,
-        setPreselectedModel,
-        selectedModel,
-        setSelectedModel,
         statusByModel,
         setStatusByModel,
         modelInstallationProgress,
@@ -420,7 +401,6 @@ const OllamaInstallStep: React.FC<StepProps> = (props) => {
 const ModelSelectionStep: React.FC<StepProps> = (props) => {
   const {
     serverState,
-    selectedModel,
     modelInstallationProgress,
     setModelInstallationProgress,
     modelInstallationStatus,
@@ -439,9 +419,7 @@ const ModelSelectionStep: React.FC<StepProps> = (props) => {
     setModelInstallationStatus("downloading");
     vscode.postMessage({
       command: "installModels",
-      data: {
-        model: selectedModel,
-      },
+      data: {},
     });
   };
 
@@ -467,7 +445,7 @@ const ModelSelectionStep: React.FC<StepProps> = (props) => {
     const sysErrors = [];
     if (systemInfo && systemInfo.diskSpace) {
       const { freeDiskSpace } = systemInfo.diskSpace;
-      const requiredDiskSpace = getRequiredSpace(selectedModel, statusByModel);
+      const requiredDiskSpace = getRequiredSpace(statusByModel);
       if (freeDiskSpace < requiredDiskSpace) {
         sysErrors.push(
           `Insufficient disk space available: ${formatSize(freeDiskSpace)} free, ${formatSize(requiredDiskSpace)} required.`,
@@ -481,7 +459,7 @@ const ModelSelectionStep: React.FC<StepProps> = (props) => {
       );
     }
     setSystemErrors(sysErrors);
-  }, [systemInfo, selectedModel, statusByModel, serverState.version]);
+  }, [systemInfo, statusByModel, serverState.version]);
 
   const serverStatus = serverState.status;
 
@@ -492,8 +470,7 @@ const ModelSelectionStep: React.FC<StepProps> = (props) => {
           <p>
             Setup will download Granite AI models.
             <br />
-            Download size:{" "}
-            {formatSize(getRequiredSpace(selectedModel, statusByModel))}.
+            Download size: {formatSize(getRequiredSpace(statusByModel))}.
           </p>
 
           <div className="mt-4 flex items-center gap-2">
@@ -603,9 +580,6 @@ const WizardContent: React.FC = () => {
     setServerState,
     setSystemInfo,
     setInstallationModes,
-    setPreselectedModel,
-    preselectedModel,
-    setSelectedModel,
     setModelInstallationProgress,
     setModelInstallationError,
     modelInstallationStatus,
@@ -670,11 +644,6 @@ const WizardContent: React.FC = () => {
           setInstallationModes(data.installModes);
           const sysinfo = data.systemInfo as SystemInfo;
           setSystemInfo(sysinfo);
-          const preselectedModel = shouldRecommendLargeModel(sysinfo)
-            ? "large"
-            : "small";
-          setPreselectedModel(preselectedModel);
-          setSelectedModel("large");
           const wizardState = data.wizardState as WizardState | undefined;
           if (wizardState?.stepStatuses) {
             setStepStatuses(wizardState.stepStatuses);
@@ -879,12 +848,6 @@ const WizardContent: React.FC = () => {
               10&#x200A;GB of video memory is required.
             </p>
           </div>
-          {preselectedModel !== "large" && (
-            <p className="mb-4 text-[--vscode-editorWarning-foreground]">
-              Warning : this device's hardware does not meet the minimum
-              requirements.
-            </p>
-          )}
         </div>
         <div className="granite-wizard-steps">
           <div className="space-y-[1px]">
@@ -914,14 +877,8 @@ const WizardContent: React.FC = () => {
   );
 };
 
-function getRequiredSpace(
-  selectedModel: LocalModelSize,
-  statusByModel: Map<string, ModelStatus>,
-): number {
-  const models =
-    selectedModel === "large"
-      ? DEFAULT_GRANITE_MODEL_IDS_LARGE
-      : DEFAULT_GRANITE_MODEL_IDS_SMALL;
+function getRequiredSpace(statusByModel: Map<string, ModelStatus>): number {
+  const models = DEFAULT_GRANITE_MODEL_IDS;
   let missingModels = models.filter(
     (model) => statusByModel.get(model) !== ModelStatus.installed,
   );


### PR DESCRIPTION
## Description

Since the small granite model is no longer our consideration for chat model, we don't need LocalModelSize to differentiate the setting for default models.
