### PR TITLE
Fix: fix import error in activate.ts

### DIFF
--- a/extensions/vscode/src/activation/activate.ts
+++ b/extensions/vscode/src/activation/activate.ts
@@ -1,16 +1,10 @@
 import * as path from "path";
 
-import { LocalModelSize } from "core";
-import {
-  DEFAULT_GRANITE_MODEL_IDS_LARGE,
-  DEFAULT_GRANITE_MODEL_IDS_SMALL,
-} from "core/config/default";
-import { EXTENSION_NAME } from "core/control-plane/env";
+import { DEFAULT_GRANITE_MODEL_IDS } from "core/config/default";
 import { GRANITE_INITIAL_ACTIVATION_COMPLETED_KEY } from "core/granite/commons/constants";
 import { getContinueRcPath, getTsConfigPath } from "core/util/paths";
 import { Telemetry } from "core/util/posthog";
 import * as vscode from "vscode";
-import { workspace } from "vscode";
 
 import { VsCodeExtension } from "../extension/VsCodeExtension";
 import { registerModelUpdater } from "../granite/ollama/modelUpdater";
@@ -109,13 +103,7 @@ export async function activateExtension(context: vscode.ExtensionContext) {
 
 export async function deactivate(context: vscode.ExtensionContext) {
   // Unload Granite LLMs from Ollama
-  const type = workspace
-    .getConfiguration(EXTENSION_NAME)
-    .get<LocalModelSize>("localModelSize");
-  const modelsToUnload =
-    type === "large"
-      ? DEFAULT_GRANITE_MODEL_IDS_LARGE
-      : DEFAULT_GRANITE_MODEL_IDS_SMALL;
+  const modelsToUnload = DEFAULT_GRANITE_MODEL_IDS;
 
   const ollamaServer = new OllamaServer(context);
   let unloadedModels = 0;


### PR DESCRIPTION
## Description

This patch is to fix the import error happened in activate.ts which was caused by merging #61. Because we merged #73 (Remove LocalModelSize and renaming) before this, the related imports in #61 are removed. Should have launched the extension one last time before merging #61.
